### PR TITLE
[chore] Limit CI Tests to Files Changed

### DIFF
--- a/addons/dashboard/dashboard.yaml
+++ b/addons/dashboard/dashboard.yaml
@@ -12,9 +12,9 @@ metadata:
     docs.kubeaddons.mesosphere.io/dashboard: "https://github.com/kubernetes/dashboard/blob/master/README.md"
     values.chart.helm.kubeaddons.mesosphere.io/dashboard: "https://raw.githubusercontent.com/helm/charts/5e7b6640dd6b566bb136fffaca1b54da392d3074/stable/kubernetes-dashboard/values.yaml"
 spec:
-  namespace: kube-system
   kubernetes:
     minSupportedVersion: v1.15.6
+  namespace: kube-system
   cloudProvider:
     - name: aws
       enabled: true

--- a/test/README.md
+++ b/test/README.md
@@ -4,3 +4,25 @@ In this directory you will find [go tests](https://golang.org/pkg/testing/) whic
 
 This uses the [Kubeaddons](https://github.com/mesosphere/kubeaddons) addon testing framework, which is [documented here](https://github.com/mesosphere/kubeaddons/blob/master/docs/test/framework.md).
 
+## New Addon Tests
+
+When addons are added to the repository, CI will fail on validation if tests (that  pass) are not provided for them.
+
+In order to add tests for a new addon you'll need to add it to an existing (or new) testing group in the [groups.yaml](/test/groups.yaml) configuration file.
+
+If you create a new testing group, you must update the test functions in [addons_test.go](/test/addons_test.go) to cover the new testing group.
+
+At it's simplest, a test of a testing group may look like the following:
+
+```golang
+func TestGeneralGroup(t *testing.T) {
+	if err := testgroup(t, "general"); err != nil {
+		t.Fatal(err)
+	}
+}
+```
+
+Where `"general"` is a testing group containing several addons to test.
+
+From here, you can expand your tests within this function.
+

--- a/test/go.mod
+++ b/test/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/emicklei/go-restful v2.11.1+incompatible // indirect
 	github.com/go-openapi/spec v0.19.4 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
-	github.com/mesosphere/kubeaddons v0.6.1-0.20191205184110-8608a87abee9
+	github.com/mesosphere/kubeaddons v0.6.1-0.20191205191456-60012764fb31
 	go.uber.org/atomic v1.5.1 // indirect
 	go.uber.org/multierr v1.4.0 // indirect
 	go.uber.org/zap v1.13.0 // indirect

--- a/test/go.mod
+++ b/test/go.mod
@@ -16,6 +16,7 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
+	gopkg.in/yaml.v2 v2.2.7
 	k8s.io/apiextensions-apiserver v0.0.0-20191121021419-88daf26ec3b8 // indirect
 	k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6 // indirect
 	sigs.k8s.io/controller-runtime v0.4.0 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -937,8 +937,8 @@ github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsO
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/mesosphere/kubeaddons v0.6.1-0.20191205184110-8608a87abee9 h1:ofQssnHGBNq5sVmM2AdJXKl0agKmNBcgmgaF78nb77s=
-github.com/mesosphere/kubeaddons v0.6.1-0.20191205184110-8608a87abee9/go.mod h1:r0Pv1TVWywZoH84yfC2FDCZ8wwOURl2OzzkyfkbMsyo=
+github.com/mesosphere/kubeaddons v0.6.1-0.20191205191456-60012764fb31 h1:wxLr56dXfUhRX3I9iIKsfZSlpz36OUIWiHGS2wssyPg=
+github.com/mesosphere/kubeaddons v0.6.1-0.20191205191456-60012764fb31/go.mod h1:2moy3SolLcTDrgr4E7HlCL5oAuwbZyIyGExJwLg0u5U=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/test/groups.yaml
+++ b/test/groups.yaml
@@ -1,0 +1,83 @@
+# ------------------------------------------------------------------------------
+# Testing Groups
+#
+# Addons need to be added to a testing group here to be validated and deploy &
+# cleanup tested. New addons need to be added to a group or CI will fail.
+#
+# NOTE: only the most recent revision of an addon will be tested. If you need
+# to run specific tests for older revisions, you'll need to write explicit tests
+# to cover that scenario.
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# General
+#
+# Addons in this testing group are simple, low on resource requirements and dont
+# require any dependencies or significant work to deploy.
+# ------------------------------------------------------------------------------
+general:
+    - "dashboard"
+    - "external-dns"
+
+# ------------------------------------------------------------------------------
+# ElasticSearch
+#
+# All ElasticSearch related addons should be tested as a part of this group
+# ------------------------------------------------------------------------------
+elasticsearch:
+    - "elasticsearch"
+    - "elasticsearchexporter"
+    - "kibana"
+    - "fluentbit"
+
+# ------------------------------------------------------------------------------
+# Prometheus
+#
+# All Prometheus related addons should be tested as a part of this group
+# ------------------------------------------------------------------------------
+prometheus:
+    - "prometheus"
+    - "prometheusadapter"
+    - "opsportal"
+
+# ------------------------------------------------------------------------------
+# Disabled
+#
+# These are Addons which tests are currently disabled for.
+# ------------------------------------------------------------------------------
+disabled:
+    # kudo gets tested in https://github.com/mesosphere/kubeaddons-enterprise, and is likely going to be removed from this repository.
+    # See: https://jira.mesosphere.com/browse/DCOS-61842
+    - "kudo"
+
+    # these are addons which are currently filtered out of tests because we're waiting on features to be able to test them properly.
+    # See: https://jira.mesosphere.com/browse/DCOS-61664
+    - "dex"
+    - "dex-k8s-authenticator"
+    - "awsebscsiprovisioner"
+    - "awsebsprovisioner"
+    - "azuredisk-csi-driver"
+    - "azurediskprovisioner"
+    - "konvoyconfig"
+    - "metallb"
+    - "nvidia"
+
+    # the following addons need tests added
+    # See: https://jira.mesosphere.com/browse/DCOS-61664
+    - "cert-manager"
+    - "dex-k8s-authenticator"
+    - "kube-oidc-proxy"
+    - "prometheusadapter"
+    - "velero"
+    - "dispatch"
+    - "kommander"
+    - "traefik"
+    - "dex"
+    - "traefik-forward-auth"
+    - "istio"
+    - "flagger"
+    - "gatekeeper"
+    - "reloader"
+    - "localvolumeprovisioner"
+    - "defaultstorageclass-protection"
+

--- a/test/scripts/test-wrapper.pl
+++ b/test/scripts/test-wrapper.pl
@@ -1,0 +1,49 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use List::Util qw(first);
+use File::Slurp;
+use YAML;
+
+my $groups = Load(scalar(read_file("groups.yaml")));
+my @lines = `git diff origin/master --name-only`;
+my $code = $?;
+if ($code != 0) {
+    print "$_\n" for @lines;
+    die("could not diff origin/master: exit code " . $code)
+}
+
+my @addons;
+foreach my $line (@lines) {
+    if ($line =~ m{^addons/([a-z]+)/?}) {
+        push(@addons, $1);
+    }
+}
+
+@addons = uniq(@addons);
+foreach my $addon (@addons) {
+    while(my($k, $v) = each %$groups) {
+        if (first { $addon eq $_ } @$v) {
+            my $group = "Test" . ucfirst($k) . "Group";
+            my $exit = system("go test -race -v -run ${group}");
+            if ($exit != 0) {
+                die "tests failed for group ${group} (exit code ${code})";
+            }
+        }
+    }
+}
+
+if (scalar(@addons) < 1) {
+    exec "go test -run TestBuild"
+}
+
+# ------------------------------------------------------------------------------
+# Private Functions
+# ------------------------------------------------------------------------------
+
+sub uniq {
+    my %seen;
+    grep !$seen{$_}++, @_;
+}
+
+1;


### PR DESCRIPTION
This PR adds cleanup to make the testing groups defined in `test/groups.yaml` instead of in go code, and adds a script to isolate tests in CI only to run group tests when a relevant addon has changed.