### PR TITLE
migrate dashboard to kubeaddons

### DIFF
--- a/addons/dashboard/2.0.x/dashboard-1.yaml
+++ b/addons/dashboard/2.0.x/dashboard-1.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
-  namespace: kube-system
+  namespace: kubeaddons
   cloudProvider:
     - name: aws
       enabled: true
@@ -46,6 +46,8 @@ spec:
         repository: kubernetesui/dashboard
         tag: v2.0.0-beta6
         pullPolicy: Always
+      extraArgs:
+        - --namespace=kubeaddons
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
In order to avoid adding kube-system as a federate namespace for kommander SSO, we are migrating dashboard to the kubeaddons namepsace, which is already federated. 