### PR TITLE
apply upgrade strategy

### DIFF
--- a/addons/dashboard/2.0.x/dashboard-1.yaml
+++ b/addons/dashboard/2.0.x/dashboard-1.yaml
@@ -11,6 +11,7 @@ metadata:
     endpoint.kubeaddons.mesosphere.io/dashboard: "/ops/portal/kubernetes/"
     docs.kubeaddons.mesosphere.io/dashboard: "https://github.com/kubernetes/dashboard/blob/master/README.md"
     values.chart.helm.kubeaddons.mesosphere.io/dashboard: "https://raw.githubusercontent.com/helm/charts/5e7b6640dd6b566bb136fffaca1b54da392d3074/stable/kubernetes-dashboard/values.yaml"
+    helmv2.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=2.0.0\", \"strategy\": \"delete\"}]"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6


### PR DESCRIPTION
This is needed to support upgrading now that dashboard has migrated to the kubeaddons namespace