### PR TITLE
dex: bump dex addon to chart version 1.6.12

### DIFF
--- a/addons/dex/2.17.x/dex-1.yaml
+++ b/addons/dex/2.17.x/dex-1.yaml
@@ -28,7 +28,7 @@ spec:
   chartReference:
     chart: dex
     repo: https://mesosphere.github.io/charts/stable
-    version: 1.6.10
+    version: 1.6.12
     values: |
       ---
       # Temporarily we're going to use our custom built container. Documentation


### PR DESCRIPTION
This includes dex controller v0.3.0 (adds more validations in admission
webhook, and bumped golang to 1.13).