### PR TITLE
kommander: Bump chart version

### DIFF
--- a/addons/kommander/1.163.x/kommander-1.yaml
+++ b/addons/kommander/1.163.x/kommander-1.yaml
@@ -30,7 +30,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.2.27
+    version: 0.2.29
     values: |
       ---
       ingress:


### PR DESCRIPTION
Blocked by https://github.com/mesosphere/charts/pull/318.
Equivalent kubeaddons-configs PR: https://github.com/mesosphere/kubeaddons-configs/pull/376

## Testing
See the Testing section in https://github.com/mesosphere/charts/pull/318#issue-354269295