### PR TITLE
chore: bump traefik to chart 1.72.9

### DIFF
--- a/addons/traefik/1.7.x/traefik-1.yaml
+++ b/addons/traefik/1.7.x/traefik-1.yaml
@@ -14,7 +14,7 @@ metadata:
     appversion.kubeaddons.mesosphere.io/traefik: "1.7.2"
     endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
     docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/v1.7"
-    values.chart.helm.kubeaddons.mesosphere.io/traefik: "https://raw.githubusercontent.com/helm/charts/c7e31361a28a10e30b4143b73439080d5e9f7d8b/stable/traefik/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/traefik: "https://raw.githubusercontent.com/mesosphere/charts/0446b8c4538dba2bb8919a6203b2b8b6c6450365/staging/traefik/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -24,7 +24,7 @@ spec:
   chartReference:
     chart: traefik
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.72.8
+    version: 1.72.9
     values: |
       ---
       replicas: 2
@@ -58,6 +58,9 @@ spec:
         # separate issue.
         # See: https://jira.mesosphere.com/browse/DCOS-56033
         insecureSkipVerify: true
+        # We use cert-manager to automate certificate management thus we
+        # do not need the default cert secret.
+        useCertManager: true
       deploymentAnnotations:
         # Watching this CM will trigger traefik init container that updates certificate
         # object with new DNS names. That will cascade secret update which will trigger


### PR DESCRIPTION
Use the new `ssl.useCertManager` introduced in https://github.com/mesosphere/charts/commit/0446b8c4538dba2bb8919a6203b2b8b6c6450365 to stop creating a certificate secret made useless by the use of cert-manager.