### PR TITLE
chore: Bump kommander version

### DIFF
--- a/addons/kommander/1.163.x/kommander-1.yaml
+++ b/addons/kommander/1.163.x/kommander-1.yaml
@@ -30,7 +30,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.3.1
+    version: 0.3.2
     values: |
       ---
       ingress:


### PR DESCRIPTION
Bump kommander chart version -- please see https://github.com/mesosphere/charts/pull/321 and https://github.com/mesosphere/charts/pull/324 for more context. This PR is currently blocked on https://github.com/mesosphere/charts/pull/324

## Testing
This was tested by pointing cluster.yaml to this repo and branch when bringing up a konvoy cluster. I verified that the karma cm included the new pre-install hooks to avoid getting overwritten during upgrades.
![image](https://user-images.githubusercontent.com/5897740/71597829-8a13d400-2af9-11ea-85fb-ed394cc7f62f.png)
To test that the cm gets cleaned up at uninstalls, I then disabled the kommander addon and verified that the cm gets deleted.
```
$ kubectl get cm -n kommander kommander-kubeaddons-config
Error from server (NotFound): configmaps "kommander-kubeaddons-config" not found
```