### PR TITLE
prometheus: bump cpu and memory

### DIFF
--- a/addons/prometheus/0.34.x/prometheus-1.yaml
+++ b/addons/prometheus/0.34.x/prometheus-1.yaml
@@ -235,10 +235,10 @@ spec:
           resources:
             limits:
               cpu: 1000m
-              memory: 2000Mi
+              memory: 2500Mi
             requests:
-              cpu: 200m
-              memory: 1000Mi
+              cpu: 300m
+              memory: 1500Mi
       alertmanager:
         alertmanagerSpec:
           resources:


### PR DESCRIPTION
Based on the observation in soak onprem (using beta8), we need to bump
the promethesus footprint. Otherwise, it will be constantly killed due
to OOM.

The increase of resources usage is likely caused by the increasing
number of default addons, resulting in more metrics being collected.

![image](https://user-images.githubusercontent.com/1778745/72039027-6159b000-3258-11ea-8724-84b9c2a358e0.png)
