### PR TITLE
prometheusadapter: Bump chart and fix metric labels

### DIFF
--- a/addons/prometheusadapter/0.5.x/prometheusadapter-1.yaml
+++ b/addons/prometheusadapter/0.5.x/prometheusadapter-1.yaml
@@ -27,7 +27,7 @@ spec:
         kubeaddons.mesosphere.io/name: prometheus
   chartReference:
     chart: stable/prometheus-adapter
-    version: 1.1.0
+    version: 2.0.0
     values: |
       ---
       prometheus:
@@ -53,7 +53,7 @@ spec:
                  resource: namespace
                 pod_name:
                  resource: pod
-            containerLabel: container_name
+            containerLabel: container
           memory:
             containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)
             nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
@@ -65,5 +65,5 @@ spec:
                  resource: namespace
                 pod_name:
                  resource: pod
-            containerLabel: container_name
+            containerLabel: container
           window: 1m

--- a/addons/prometheusadapter/0.5.x/prometheusadapter-1.yaml
+++ b/addons/prometheusadapter/0.5.x/prometheusadapter-1.yaml
@@ -51,7 +51,7 @@ spec:
                  resource: node
                 namespace:
                  resource: namespace
-                pod_name:
+                pod:
                  resource: pod
             containerLabel: container
           memory:
@@ -63,7 +63,7 @@ spec:
                  resource: node
                 namespace:
                  resource: namespace
-                pod_name:
+                pod:
                  resource: pod
             containerLabel: container
           window: 1m


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-62708 Metric label names changed in k8s 1.16+, accounting for those here. I bumped the revision here but I'm not actually sure what the rules around that are, so let me know if I did that correctly!

Currently blocked on upstream chart https://github.com/helm/charts/pull/19961. Once that is merged, this PR is unblocked.

## Testing
TODO