### PR TITLE
prometheusadapter: tweak some interval windows

### DIFF
--- a/addons/prometheusadapter/0.5.x/prometheusadapter-1.yaml
+++ b/addons/prometheusadapter/0.5.x/prometheusadapter-1.yaml
@@ -39,12 +39,12 @@ spec:
         requests:
            cpu: 1000m
            memory: 1000Mi
-      metricsRelistInterval: 30s
+      metricsRelistInterval: 60s
       rules:
         resource:
           cpu:
-            containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
-            nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[1m])) by (<<.GroupBy>>)
+            containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[2m])) by (<<.GroupBy>>)
+            nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[2m])) by (<<.GroupBy>>)
             resources:
               overrides:
                 node:


### PR DESCRIPTION
This is to reduce flakiness. By default, our Promethesus instance will
scrape at 30s interval for all metrics. As a result, we tweak the
following windows for prometheus adapter:

1. Set `--metrics-relist-interval` to 60s. As suggested in the document,
This is the interval at which to update the cache of available metrics
from Prometheus. Since the adapter only lists metrics during discovery
that exist between the current time and the last discovery query, your
relist interval should be equal to or larger than your Prometheus scrape
interval, otherwise your metrics will occaisonally disappear from the
adapter.

2. Set `rate()` interval to be 2m. `rate()` will only be meaningful if
there are at least two samples within the interval window. It is
recommended to use a 2m interval for a scrape interval of 30s.

Manually tested this config in a live cluster. Running the following command was flaky in the sense that the number of nodes show up in the result is non deterministic prior to applying this patch. After applying this patch, problem is resolved.

```
watch -n 3 'kubectl get nodes.metrics.k8s.io'
Every 3.0s: kubectl get nodes.metrics.k8s.io                                                                                                                                                                                             Jies-MacBook-Pro.local: Fri Jan 10 10:51:29 2020

NAME                                         AGE
ip-10-0-131-208.us-west-2.compute.internal   0s
ip-10-0-131-183.us-west-2.compute.internal   0s
ip-10-0-193-61.us-west-2.compute.internal    0s
ip-10-0-128-231.us-west-2.compute.internal   0s
ip-10-0-128-97.us-west-2.compute.internal    0s
```