### PR TITLE
[kibana] chore: added kibana-6.8.2

### DIFF
--- a/addons/kibana/6.8.x/kibana-1.yaml
+++ b/addons/kibana/6.8.x/kibana-1.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: kibana
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: kibana
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.0-1"
+    appversion.kubeaddons.mesosphere.io/kibana: "6.8.2"
+    endpoint.kubeaddons.mesosphere.io/kibana: "/ops/portal/kibana"
+    docs.kubeaddons.mesosphere.io/kibana: "https://www.elastic.co/guide/en/kibana/6.8/index.html"
+    values.chart.helm.kubeaddons.mesosphere.io/kibana: "https://raw.githubusercontent.com/helm/charts/09004fa332094693e2e5fcffe474622ba15491ae/stable/kibana/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: true
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: elasticsearch
+  chartReference:
+    chart: stable/kibana
+    version: 3.2.5
+    values: |
+      ---
+      image:
+        tag: "6.8.2"
+      files:
+        kibana.yml:
+          ## Default Kibana configuration from kibana-docker.
+          elasticsearch.url: http://elasticsearch-kubeaddons-client:9200
+          ## Ref: https://www.elastic.co/guide/en/kibana/current/settings.html
+          server.basePath: /ops/portal/kibana
+      serviceAccount:
+        create: true
+      service:
+        type: ClusterIP
+        externalPort: 5601
+        internalPort: 5601
+        labels:
+          servicemonitor.kubeaddons.mesosphere.io/path: "prometheus__metrics"
+      resources:
+        # need more cpu upon initialization, therefore burstable class
+        limits:
+          cpu: 1000m
+        requests:
+          cpu: 100m
+      plugins:
+        # to avoid needing to download any plugins at runtime, use a container and a shared volume
+        # do not enable the plugins here, instead rebuild the mesosphere/kibana-plugins image with the new plugins
+        enabled: false
+        values:
+          - kibana-prometheus-exporter,6.8.2,https://github.com/pjhampton/kibana-prometheus-exporter/releases/download/6.8.2/kibana-prometheus-exporter-6.8.2.zip
+      extraContainers: |
+        - name: initialize-kibana-index
+          image: mesosphere/kubeaddons-addon-initializer:v0.1.5
+          command: ["/bin/bash", "-c", "addon-initializer kibana && sleep infinity"]
+          env:
+          - name: "KIBANA_NAMESPACE"
+            value: "kubeaddons"
+          - name: "KIBANA_SERVICE_NAME"
+            value: "kibana-kubeaddons"
+      initContainers:
+        # from https://github.com/mesosphere/kubeaddons-sidecars
+        - name: kibana-plugins-install
+          image: mesosphere/kibana-plugins:v6.8.2
+          command: ["/bin/sh", "-c", "cp -a /usr/share/kibana/plugins/. /usr/share/kibana/shared-plugins/"]
+          volumeMounts:
+          - name: plugins
+            mountPath: /usr/share/kibana/shared-plugins/
+      extraVolumes:
+        - name: plugins
+          emptyDir: {}
+      extraVolumeMounts:
+        - mountPath: /usr/share/kibana/plugins/
+          name: plugins


### PR DESCRIPTION
Kibana version updated to the version of elastic search, this stops the logs warning about the mismatch.

- image was updated to the correct version
- correct plugin version 
- all labels were updated for UI

Kibana is up and running
```
Every 2.0s: kubectl get addons --...  gaussphere.lan: Fri Jan 10 12:02:59 2020

NAMESPACE    NAME                    READY   STAGE
kubeaddons   dex                     true    deployed
kubeaddons   dex-k8s-authenticator   true    deployed
kubeaddons   elasticsearch           true    deployed
kubeaddons   elasticsearchexporter   true    deployed
kubeaddons   fluentbit               true    deployed
kubeaddons   gatekeeper              true    deployed
kubeaddons   kibana                  true    deployed
kubeaddons   konvoyconfig            true    deployed
kubeaddons   kube-oidc-proxy         true    deployed
kubeaddons   opsportal               true    deployed
kubeaddons   prometheus              true    deployed
kubeaddons   prometheusadapter       true    deployed
kubeaddons   reloader                true    deployed
kubeaddons   traefik-forward-auth    true    deployed
```

index logs
```
 k logs -f kibana-kubeaddons-5b44d8fdb6-jqn28 -n kubeaddons initialize-kibana-index
2020/01/10 19:48:22 can't yet reach kibana: Get http://kibana-kubeaddons.kubeaddons.svc:5601: dial tcp 10.0.47.82:5601: i/o timeout
2020/01/10 19:48:22 waiting for kibana to be responsive
2020/01/10 19:48:22 kibana is ready and responding
```

