### PR TITLE
Cherry-pick stage annotations for 1.3.0 release.

### DIFF
--- a/addons/dispatch/0.4.x/dispatch-1.yaml
+++ b/addons/dispatch/0.4.x/dispatch-1.yaml
@@ -11,9 +11,11 @@ metadata:
     appversion.kubeaddons.mesosphere.io/dispatch: "0.4.2"
     endpoint.kubeaddons.mesosphere.io/dispatch: /dispatch/tekton/
     docs.kubeaddons.mesosphere.io/dispatch: "https://beta-dispatch.d2iq.com/"
+    stage.kubeaddons.mesosphere.io/dispatch: Beta
     appversion.kubeaddons.mesosphere.io/argo-cd: "1.2.0"
     endpoint.kubeaddons.mesosphere.io/argo-cd: /dispatch/argo-cd
     docs.kubeaddons.mesosphere.io/argo-cd: "https://argoproj.github.io/argo-cd/user-guide/"
+    stage.kubeaddons.mesosphere.io/argo-cd: Beta
     values.chart.helm.kubeaddons.mesosphere.io/dispatch: "https://raw.githubusercontent.com/mesosphere/charts/master/stable/dispatch/values.yaml"
 spec:
   namespace: dispatch

--- a/addons/istio/1.3.x/istio-1.yaml
+++ b/addons/istio/1.3.x/istio-1.yaml
@@ -10,6 +10,8 @@ metadata:
     appversion.kubeaddons.mesosphere.io/istio: "1.3.3"
     appversion.kubeaddons.mesosphere.io/kiali: "1.3.3"
     appversion.kubeaddons.mesosphere.io/jaeger: "1.3.3"
+    stage.kubeaddons.mesosphere.io/kiali: Preview
+    stage.kubeaddons.mesosphere.io/jaeger: Preview
     endpoint.kubeaddons.mesosphere.io/kiali: "/ops/portal/kiali"
     endpoint.kubeaddons.mesosphere.io/jaeger: "/ops/portal/jaeger"
     docs.kubeaddons.mesosphere.io/istio: "https://istio.io/docs/"


### PR DESCRIPTION
Dispatch is still in Beta.

(cherry picked from commit b0457abd7e6935a838f834108b8239d12021e626)