### PR TITLE
kommander: use repository-tag as version strategy

### DIFF
--- a/addons/kommander/1.163.x/kommander-1.yaml
+++ b/addons/kommander/1.163.x/kommander-1.yaml
@@ -51,12 +51,7 @@ spec:
         konvoy:
           allowUnofficialReleases: true
         kubeaddonsRepository:
-          versionStrategy: mapped-kubernetes-version
-          versionMap:
-            1.15.4: kommander-beta4
-            1.15.5: kommander-beta6
-            1.15.6: kommander-beta9
-            1.16.3: kommander-beta9
+          versionStrategy: repository-tag
 
       kommander-karma:
         karma:

--- a/addons/kommander/1.163.x/kommander-1.yaml
+++ b/addons/kommander/1.163.x/kommander-1.yaml
@@ -50,8 +50,6 @@ spec:
             kind: ClusterIssuer
         konvoy:
           allowUnofficialReleases: true
-        kubeaddonsRepository:
-          versionStrategy: repository-tag
 
       kommander-karma:
         karma:

--- a/addons/kommander/1.173.x/kommander-1.yaml
+++ b/addons/kommander/1.173.x/kommander-1.yaml
@@ -44,12 +44,6 @@ spec:
             kind: ClusterIssuer
         konvoy:
           allowUnofficialReleases: true
-        kubeaddonsRepository:
-          versionStrategy: mapped-kubernetes-version
-          versionMap:
-            1.15.6: v1.3.0-rc.1
-            1.16.3: v1.3.0-rc.1
-            1.16.4: v1.3.0-rc.1
 
       kommander-karma:
         karma:


### PR DESCRIPTION
We should rely on the kuberentes-base-addons tags to pick the tag version that matches the selected kubernetes version.