### PR TITLE
gatekeeper: version bump

### DIFF
--- a/addons/gatekeeper/3.0.x/gatekeeper-1.yaml
+++ b/addons/gatekeeper/3.0.x/gatekeeper-1.yaml
@@ -29,7 +29,7 @@ spec:
   chartReference:
     chart: gatekeeper
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.1.0
+    version: 0.3.3
     values: |
       ---
       image:


### PR DESCRIPTION
I am surprised why we didn't bump gatekeeper from 0.1.0 to 0.3.0 yet 🤔 