### PR TITLE
addons/velero: bump minio k8s operator to 1.0.6 (security update)

### DIFF
--- a/addons/velero/1.0.x/velero-1.yaml
+++ b/addons/velero/1.0.x/velero-1.yaml
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: velero
     repo: https://mesosphere.github.io/charts/staging
-    version: 2.2.9
+    version: 2.2.11
     values: |
       ---
       configuration:


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/DCOS-62691

Our `velero` chart is modified and includes `minio` deployemnt. The `minio` is not included in upstream `velero` chart - https://github.com/vmware-tanzu/helm-charts/blob/f721d7a7138e0c3138a89fe9c097c35d9e4ee2cd/README.md

Builds:

- aws - https://teamcity.mesosphere.io/viewLog.html?buildId=2547553&buildTypeId=ClosedSource_MkeLite_MkeLiteE2e
- azure - https://teamcity.mesosphere.io/viewLog.html?buildId=2547551&buildTypeId=ClosedSource_Konvoy_KonvoyE2eAzure
- docker - https://teamcity.mesosphere.io/viewLog.html?buildId=2547555&buildTypeId=ClosedSource_Konvoy_KonvoyE2eDocker
