### PR TITLE
[1.3.0] backport latest kommander bump

### DIFF
--- a/addons/kommander/1.184.x/kommander-1.yaml
+++ b/addons/kommander/1.184.x/kommander-1.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: kommander
+  labels:
+    kubeaddons.mesosphere.io/name: kommander
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.184.0-1"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.184.0"
+    endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
+    appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
+    appversion.kubeaddons.mesosphere.io/karma: 1.4.0
+    appversion.kubeaddons.mesosphere.io/kommander-grafana: 6.4.2
+    endpoint.kubeaddons.mesosphere.io/thanos: /ops/portal/kommander/monitoring/query
+    endpoint.kubeaddons.mesosphere.io/karma: /ops/portal/kommander/monitoring/karma
+    endpoint.kubeaddons.mesosphere.io/kommander-grafana: "/ops/portal/kommander/monitoring/grafana"
+    docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
+    docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
+    docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/master/stable/kommander/values.yaml"
+    helmv2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=0.1.22", "strategy": "delete"}]'
+spec:
+  namespace: kommander
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: cert-manager
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  chartReference:
+    chart: kommander
+    repo: https://mesosphere.github.io/charts/stable
+    version: 0.3.14
+    values: |
+      ---
+      ingress:
+        extraAnnotations:
+          traefik.ingress.kubernetes.io/priority: "2"
+
+      kommander-cluster-lifecycle:
+        certificates:
+          issuer:
+            name: kubernetes-ca
+            kind: ClusterIssuer
+        konvoy:
+          allowUnofficialReleases: true
+        kubeaddonsRepository:
+          versionStrategy: mapped-kubernetes-version
+          versionMap:
+            1.15.6: v1.3.0-rc.1
+            1.16.3: v1.3.0-rc.1
+            1.16.4: v1.3.0-rc.1
+
+      kommander-karma:
+        karma:
+          deployment:
+            annotations:
+              configmap.reloader.stakater.com/reload: kommander-kubeaddons-config
+
+      federate:
+        kubeaddons:
+          image:
+            repository: "mesosphere/kubeaddons"
+            tag: "v0.5.3"
+            pullPolicy: IfNotPresent
+
+      kubeaddons-catalog:
+        image:
+          repository: mesosphere/kubeaddons-catalog
+          tag: "v0.5.3"
+          pullPolicy: IfNotPresent

--- a/addons/kommander/1.184.x/kommander-1.yaml
+++ b/addons/kommander/1.184.x/kommander-1.yaml
@@ -53,12 +53,6 @@ spec:
             kind: ClusterIssuer
         konvoy:
           allowUnofficialReleases: true
-        kubeaddonsRepository:
-          versionStrategy: mapped-kubernetes-version
-          versionMap:
-            1.15.6: v1.3.0-rc.1
-            1.16.3: v1.3.0-rc.1
-            1.16.4: v1.3.0-rc.1
 
       kommander-karma:
         karma:

--- a/addons/opsportal/1.0.x/opsportal-1.yaml
+++ b/addons/opsportal/1.0.x/opsportal-1.yaml
@@ -26,7 +26,7 @@ spec:
   chartReference:
     chart: opsportal
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.1.25
+    version: 0.1.28
     values: |
       ---
       landing:


### PR DESCRIPTION
backporting latest master bump (this one: https://github.com/mesosphere/kubernetes-base-addons/pull/68) to 1.3.0 branch. it shouldnt impact konvoy in any way, only updating kommander addon. will do some final tests with this branch tho.

How to test?

create cluster.yaml and change `configVersion` to this branch:
```
addons:
    - configRepository: https://github.com/mesosphere/kubernetes-base-addons
      configVersion: jg/kommander-backport-1.3
```