### PR TITLE
chore: bump fluentbit memory due to OOM

### DIFF
--- a/addons/fluentbit/1.3.x/fluentbit-1.yaml
+++ b/addons/fluentbit/1.3.x/fluentbit-1.yaml
@@ -64,7 +64,7 @@ spec:
          Strip_Underscores true
       resources:
         limits:
-          memory: 500Mi
+          memory: 750Mi
         requests:
           # values extracted from a 1 output/1 input setup here:
           # https://github.com/fluent/fluent-bit-kubernetes-logging/blob/master/fluent-bit-daemonset-kafka-rest.yml


### PR DESCRIPTION
We should increase the fluentbit memory limit due to OOM on the soak cluster. I'd keep one eye on the cluster to validate this new limit is good enough, otherwise I'll increase it up to 1Gb