### PR TITLE
[elasticsearch-curator] introduce curator to our stack

### DIFF
--- a/addons/elasticsearch-curator/5.7.x/elasticsearch-curator-1.yaml
+++ b/addons/elasticsearch-curator/5.7.x/elasticsearch-curator-1.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: elasticsearch-curator
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: elasticsearch-curator
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "5.7.6-1"
+    appversion.kubeaddons.mesosphere.io/elasticsearch-curator: "5.7.6"
+    values.chart.helm.kubeaddons.mesosphere.io/elasticsearch-curator: "https://raw.githubusercontent.com/helm/charts/2967c0e1590fe86bed41d2219ace376e22930cb6/stable/elasticsearch-curator/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: true
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: elasticsearch
+  chartReference:
+    chart: stable/elasticsearch-curator
+    version: 2.1.3
+    values: |
+      ---
+      resources: {}
+
+      cronjob:
+        # At 12:00 pm every day
+        schedule: "0 0 * * *"
+        annotations: {}
+        labels: {}
+        concurrencyPolicy: ""
+        failedJobsHistoryLimit: ""
+        successfulJobsHistoryLimit: ""
+        jobRestartPolicy: Never
+
+      pod:
+        annotations: {}
+        labels: {}
+
+      rbac:
+        enabled: true
+
+      configMaps:
+        # Delete indices older than 30 days
+        action_file_yml: |-
+          ---
+          actions:
+            1:
+              action: delete_indices
+              description: "Clean up ES by deleting indices older than 30 days"
+              options:
+                timeout_override:
+                continue_if_exception: False
+                disable_action: False
+                ignore_empty_list: True
+              filters:
+              - filtertype: pattern
+                kind: prefix
+                value: kubernetes_cluster-
+              - filtertype: age
+                source: name
+                direction: older
+                timestring: '%Y.%m.%d'
+                unit: days
+                unit_count: 30
+
+        # Having config_yaml WILL override the other config
+        config_yml: |-
+          ---
+          client:
+            hosts:
+              - http://elasticsearch-kubeaddons-client
+            port: 9200

--- a/test/addons_test.go
+++ b/test/addons_test.go
@@ -65,7 +65,7 @@ func TestGeneralGroup(t *testing.T) {
 	}
 }
 
-func TestElasticSearchGroup(t *testing.T) {
+func TestElasticsearchGroup(t *testing.T) {
 	if err := testgroup(t, "elasticsearch"); err != nil {
 		t.Fatal(err)
 	}

--- a/test/addons_test.go
+++ b/test/addons_test.go
@@ -171,7 +171,7 @@ func testgroup(t *testing.T, groupname string) error {
 	}()
 
 	cluster, err := kind.NewCluster(version, create.WithV1Alpha3(&v1alpha3.Cluster{
-		Nodes: []v1alpha3.Node{ node, },
+		Nodes: []v1alpha3.Node{node},
 	}))
 	if err != nil {
 		return err

--- a/test/groups.yaml
+++ b/test/groups.yaml
@@ -41,6 +41,7 @@ elasticsearch:
     - "elasticsearchexporter"
     - "kibana"
     - "fluentbit"
+    - "elasticsearch-curator"
 
 # ------------------------------------------------------------------------------
 # Prometheus

--- a/test/scripts/test-wrapper.go
+++ b/test/scripts/test-wrapper.go
@@ -89,5 +89,9 @@ func getGroupsToTest(modifiedAddons []addonName) ([]groupName, error) {
 		}
 	}
 
+	if len(testGroups) < 1 {
+		return nil, fmt.Errorf("error: there were no testGroups to test")
+	}
+
 	return testGroups, nil
 }

--- a/test/scripts/test-wrapper.go
+++ b/test/scripts/test-wrapper.go
@@ -75,7 +75,15 @@ func getGroupsToTest(modifiedAddons []addonName) ([]groupName, error) {
 		for group, addons := range g {
 			for _, name := range addons {
 				if name == modifiedAddonName {
-					testGroups = append(testGroups, group)
+					exists := false
+					for _, existingGroup := range testGroups {
+						if group == existingGroup {
+							exists = true
+						}
+					}
+					if !exists {
+						testGroups = append(testGroups, group)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
 DO NOT MERGE YET

tested this in soak:

before running cronjob:

```
curl -XGET localhost:9200/_cat/allocation?v
shards disk.indices disk.used disk.avail disk.total disk.percent host            ip              node
    52       25.9gb    26.4gb      2.9gb     29.4gb           90 192.168.213.144 192.168.213.144 elasticsearch-kubeaddons-data-3
    31        7.5gb      27gb      2.3gb     29.4gb           91 192.168.180.111 192.168.180.111 elasticsearch-kubeaddons-data-0
     3      623.6mb    26.4gb      2.9gb     29.4gb           90 192.168.226.68  192.168.226.68  elasticsearch-kubeaddons-data-5
    38       26.7gb    27.2gb      2.1gb     29.4gb           92 192.168.211.150 192.168.211.150 elasticsearch-kubeaddons-data-4
    39       26.7gb    26.8gb      2.5gb     29.4gb           91 192.168.210.148 192.168.210.148 elasticsearch-kubeaddons-data-2
    35       26.2gb    26.6gb      2.7gb     29.4gb           90 192.168.58.80   192.168.58.80   elasticsearch-kubeaddons-data-1
```

after:

```
curl -XGET localhost:9200/_cat/allocation?v
shards disk.indices disk.used disk.avail disk.total disk.percent host            ip              node
    56       21.7gb    22.2gb      7.1gb     29.4gb           75 192.168.213.144 192.168.213.144 elasticsearch-kubeaddons-data-3
    56       16.3gb    16.6gb     12.7gb     29.4gb           56 192.168.58.80   192.168.58.80   elasticsearch-kubeaddons-data-1
    56       23.2gb    23.7gb      5.6gb     29.4gb           80 192.168.211.150 192.168.211.150 elasticsearch-kubeaddons-data-4
    55         21gb    21.4gb      7.9gb     29.4gb           72 192.168.226.68  192.168.226.68  elasticsearch-kubeaddons-data-5
    55       18.4gb    18.5gb     10.8gb     29.4gb           63 192.168.180.111 192.168.180.111 elasticsearch-kubeaddons-data-0
    54       19.6gb    19.8gb      9.5gb     29.4gb           67 192.168.210.148 192.168.210.148 elasticsearch-kubeaddons-data-2
```

This is currently running in AWS Soak.

Logs of successful run:

```
ka logs -f elasticsearch-curator-kubeaddons-1579724280-dfmzj
2020-01-22 20:18:08,606 INFO      Preparing Action ID: 1, "delete_indices"
2020-01-22 20:18:08,613 INFO      Trying Action ID: 1, "delete_indices": Clean up ES by deleting indices older than 30 days
2020-01-22 20:18:08,718 INFO      Deleting 3 selected indices: ['kubernetes_cluster-2019.12.22', 'kubernetes_cluster-2019.12.21', 'kubernetes_cluster-2019.12.23']
2020-01-22 20:18:08,718 INFO      ---deleting index kubernetes_cluster-2019.12.22
2020-01-22 20:18:08,718 INFO      ---deleting index kubernetes_cluster-2019.12.21
2020-01-22 20:18:08,718 INFO      ---deleting index kubernetes_cluster-2019.12.23
2020-01-22 20:18:09,391 INFO      Action ID: 1, "delete_indices" completed.
2020-01-22 20:18:09,391 INFO      Job completed.
```

Customer Impact:
This allows the customer a means to delete older indices that they may not want to maintain and free up storage from the PVs automatically with little human interaction. The alternative would be to manually make calls to ElasticSearch and free up storage when alerts are being fired. 