### PR TITLE
chore: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,6 @@ Enter your extended release note in the block below. If the PR requires addition
 
 * [ ] The commit message explains the changes and why are needed.
 * [ ] The code builds and passes lint/style checks locally.
-* [ ] The relevant subset of e2e tests pass locally.
-* [ ] The core changes are covered by unit tests.
-* [ ] The core changes are covered by e2e tests.
+* [ ] The relevant subset of integration tests pass locally.
+* [ ] The core changes are covered by tests.
 * [ ] The documentation is updated where needed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+**What type of PR is this?**
+<!-- Bug, Chore, Documentation, Feature -->
+
+**What this PR does/ why we need it**:
+<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
+
+**Which issue(s) this PR fixes**:
+<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
+
+**Special notes for your reviewer**:
+
+**Does this PR introduce a user-facing change?**:
+<!--
+If no, just write "NONE" in the release-note block below.
+If yes, a release note is required:
+Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
+-->
+```release-note
+
+```
+
+**Checklist**
+
+* [ ] The commit message explains the changes and why are needed.
+* [ ] The code builds and passes lint/style checks locally.
+* [ ] The relevant subset of e2e tests pass locally.
+* [ ] The core changes are covered by unit tests.
+* [ ] The core changes are covered by e2e tests.
+* [ ] The documentation is updated where needed.


### PR DESCRIPTION
This template is a copy from Konvoy repo. Not only does it help
standardize PR descriptions but the underlying intent is to make sure
that we have a consistent setup for release notes. Engineers are
encouraged to add release notes whenever there is a public facing
change.

This simplifies the release process whereby now release-notes
can be generated automatically vs a dev having to manually scour PRs and
commitlog to understand what changes were made from the last release.