### PR TITLE
Added prometheus as a prerequisite of dispatch.

### DIFF
--- a/addons/dispatch/0.3.x/dispatch-1.yaml
+++ b/addons/dispatch/0.3.x/dispatch-1.yaml
@@ -29,6 +29,9 @@ spec:
       enabled: false
     - name: none
       enabled: false
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: prometheus
   chartReference:
     chart: dispatch
     repo: https://mesosphere.github.io/charts/stable

--- a/addons/dispatch/0.4.x/dispatch-1.yaml
+++ b/addons/dispatch/0.4.x/dispatch-1.yaml
@@ -30,6 +30,9 @@ spec:
       enabled: false
     - name: none
       enabled: false
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: prometheus
   chartReference:
     chart: dispatch
     repo: https://mesosphere.github.io/dispatch


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-63399

Since we've turned `global.prometheus.enabled` on, service monitors will be installed, which depends on `prometheus`.