### PR TITLE
bump/add new revisions for opsportal/kommander charts

### DIFF
--- a/addons/kommander/1.x/kommander-2.yaml
+++ b/addons/kommander/1.x/kommander-2.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-2"
     appversion.kubeaddons.mesosphere.io/kommander: "1.0.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.3.20
+    version: 0.3.21
     values: |
       ---
       ingress:

--- a/addons/kommander/1.x/kommander-2.yaml
+++ b/addons/kommander/1.x/kommander-2.yaml
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.3.21
+    version: 0.3.22
     values: |
       ---
       ingress:

--- a/addons/kommander/1.x/kommander-2.yaml
+++ b/addons/kommander/1.x/kommander-2.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: kommander
+  labels:
+    kubeaddons.mesosphere.io/name: kommander
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-1"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.0.0"
+    endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
+    appversion.kubeaddons.mesosphere.io/thanos: 0.3.9
+    appversion.kubeaddons.mesosphere.io/karma: 1.4.0
+    appversion.kubeaddons.mesosphere.io/kommander-grafana: 6.4.2
+    endpoint.kubeaddons.mesosphere.io/thanos: /ops/portal/kommander/monitoring/query
+    endpoint.kubeaddons.mesosphere.io/karma: /ops/portal/kommander/monitoring/karma
+    endpoint.kubeaddons.mesosphere.io/kommander-grafana: "/ops/portal/kommander/monitoring/grafana"
+    docs.kubeaddons.mesosphere.io/thanos: "https://thanos.io/getting-started.md/"
+    docs.kubeaddons.mesosphere.io/karma: "https://github.com/prymitive/karma"
+    docs.kubeaddons.mesosphere.io/kommander-grafana: "https://grafana.com/docs/"
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/master/stable/kommander/values.yaml"
+    helmv2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=0.1.22", "strategy": "delete"}]'
+spec:
+  namespace: kommander
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: cert-manager
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  chartReference:
+    chart: kommander
+    repo: https://mesosphere.github.io/charts/stable
+    version: 0.3.15
+    values: |
+      ---
+      ingress:
+        extraAnnotations:
+          traefik.ingress.kubernetes.io/priority: "2"
+
+      kommander-cluster-lifecycle:
+        certificates:
+          issuer:
+            name: kubernetes-ca
+            kind: ClusterIssuer
+        konvoy:
+          allowUnofficialReleases: true
+
+      kommander-karma:
+        karma:
+          deployment:
+            annotations:
+              configmap.reloader.stakater.com/reload: kommander-kubeaddons-config
+
+      kubeaddons-catalog:
+        image:
+          repository: mesosphere/kubeaddons-catalog
+          tag: "v0.5.3"
+          pullPolicy: IfNotPresent

--- a/addons/kommander/1.x/kommander-2.yaml
+++ b/addons/kommander/1.x/kommander-2.yaml
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.3.19
+    version: 0.3.20
     values: |
       ---
       ingress:

--- a/addons/kommander/1.x/kommander-2.yaml
+++ b/addons/kommander/1.x/kommander-2.yaml
@@ -39,7 +39,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.3.15
+    version: 0.3.19
     values: |
       ---
       ingress:

--- a/addons/kommander/1.x/kommander-2.yaml
+++ b/addons/kommander/1.x/kommander-2.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-3"
     appversion.kubeaddons.mesosphere.io/kommander: "1.0.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9

--- a/addons/kommander/1.x/kommander-2.yaml
+++ b/addons/kommander/1.x/kommander-2.yaml
@@ -32,6 +32,8 @@ spec:
       enabled: true
     - name: azure
       enabled: true
+    - name: gcp
+      enabled: true
     - name: docker
       enabled: true
     - name: none

--- a/addons/kommander/1.x/kommander-2.yaml
+++ b/addons/kommander/1.x/kommander-2.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-2"
     appversion.kubeaddons.mesosphere.io/kommander: "1.0.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander/ui
     appversion.kubeaddons.mesosphere.io/thanos: 0.3.9

--- a/addons/opsportal/1.0.x/opsportal-3.yaml
+++ b/addons/opsportal/1.0.x/opsportal-3.yaml
@@ -28,7 +28,7 @@ spec:
   chartReference:
     chart: opsportal
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.1.31
+    version: 0.1.32
     values: |
       ---
       landing:

--- a/addons/opsportal/1.0.x/opsportal-3.yaml
+++ b/addons/opsportal/1.0.x/opsportal-3.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: opsportal
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-3"
     appversion.kubeaddons.mesosphere.io/opsportal: "1.0.0"
     endpoint.kubeaddons.mesosphere.io/opsportal: /ops/portal/
     values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/4155f480571eaf82c64ddd63d3d334b1105d0591/stable/opsportal/values.yaml"

--- a/addons/opsportal/1.0.x/opsportal-3.yaml
+++ b/addons/opsportal/1.0.x/opsportal-3.yaml
@@ -28,7 +28,7 @@ spec:
   chartReference:
     chart: opsportal
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.1.30
+    version: 0.1.31
     values: |
       ---
       landing:

--- a/addons/opsportal/1.0.x/opsportal-3.yaml
+++ b/addons/opsportal/1.0.x/opsportal-3.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: opsportal
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: opsportal
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-2"
+    appversion.kubeaddons.mesosphere.io/opsportal: "1.0.0"
+    endpoint.kubeaddons.mesosphere.io/opsportal: /ops/portal/
+    values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/4155f480571eaf82c64ddd63d3d334b1105d0591/stable/opsportal/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  chartReference:
+    chart: opsportal
+    repo: https://mesosphere.github.io/charts/stable
+    version: 0.1.30
+    values: |
+      ---
+      landing:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      opsportal:
+        ingress:
+          paths: []


### PR DESCRIPTION
bumping kommander & ops portal charts by adding new revisions.

I made two commits to keep changes visible, first commit is duplicating files, second commit does the change: https://github.com/mesosphere/kubernetes-base-addons/pull/100/commits/dd5e4e7470a90f728972b3be9f19542919241cd1

@shaneutt last double checking that this is correct, mind having a look? 🙇 