### PR TITLE
chore: tests - clean cluster if reference is available but failed to create

### DIFF
--- a/test/addons_test.go
+++ b/test/addons_test.go
@@ -171,6 +171,10 @@ func testgroup(t *testing.T, groupname string) error {
 		Nodes: []v1alpha3.Node{node},
 	}))
 	if err != nil {
+		// try to clean up in case cluster was created and reference available
+		if cluster != nil {
+			_ = cluster.Cleanup()
+		}
 		return err
 	}
 	defer cluster.Cleanup()


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Small addition to help clean up a cluster in case it creates but fails checks for readiness. 
Requires https://github.com/mesosphere/kubeaddons/pull/722
 
**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [X] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
