### PR TITLE
[dex, tfa] allow ops-portal landing page to regenerate username/password

### DIFF
--- a/addons/dex/2.17.x/dex-2.yaml
+++ b/addons/dex/2.17.x/dex-2.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: dex
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: dex
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "2.17.0-2"
+    appversion.kubeaddons.mesosphere.io/dex: "2.17.0"
+    values.chart.helm.kubeaddons.mesosphere.io/dex: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/dex/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/provides: ingresscontroller
+  chartReference:
+    chart: dex
+    repo: https://mesosphere.github.io/charts/stable
+    version: 1.6.13
+    values: |
+      ---
+      # Temporarily we're going to use our custom built container. Documentation
+      # for how to build a new version: https://github.com/mesosphere/dex/blob/v2.17.0-mesosphere/README.mesosphere.md
+      image: mesosphere/dex
+      imageTag: v2.17.0-25-g5597-mesosphere
+      resources:
+        requests:
+          cpu: 100m
+          memory: 50Mi
+      deploymentAnnotations:
+        # The certificate can change because it was rotated or different cluster
+        # DNS name has been set.
+        secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate,ops-portal-credentials"
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.class: traefik
+          ingress.kubernetes.io/protocol: https
+        path: /dex
+        hosts:
+          - ""
+      ports:
+        - name: https
+          containerPort: 8080
+          protocol: TCP
+      certs:
+        web:
+          create: false
+          secret:
+            tlsName: dex
+      config:
+        issuer: https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex
+        frontend:
+          issuer: Kubernetes
+          theme: d2iq
+        storage:
+          type: kubernetes
+          config:
+            inCluster: true
+        logger:
+          level: debug
+        web:
+          http: 127.0.0.1:8081
+          https: 0.0.0.0:8080
+          tlsCert: /etc/dex/tls/https/server/tls.crt
+          tlsKey: /etc/dex/tls/https/server/tls.key
+        grpc:
+          addr: 0.0.0.0:5000
+          tlsCert: /etc/dex/tls/grpc/server/tls.crt
+          tlsKey: /etc/dex/tls/grpc/server/tls.key
+          tlsClientCA: /etc/dex/tls/grpc/ca/tls.crt
+        oauth2:
+          skipApprovalScreen: true
+        staticClients:
+        # `redirectURIs` and `secret` values are modified in `configureDexStaticClients`
+        - id: kube-apiserver
+          # This `id` must by in sync with `dex-k8s-authenticator.yaml` value as well as
+          # kube-apiserver flag `oidc-client-id`.
+          name: 'Kubernetes CLI authenticator'
+          redirectURIs:
+            - 'https://PUBLIC.URI/token/callback/kubernetes-cluster'
+            - 'https://PUBLIC.URI/token/callback'
+        - id: traefik-forward-auth
+          name: 'Ops Portal authenticator'
+          redirectURIs:
+            - 'https://PUBLIC.URI/_oauth'
+      initContainers:
+      - name: initialize-dex
+        image: mesosphere/kubeaddons-addon-initializer:v0.1.7
+        args: ["dex"]
+        env:
+        - name: "DEX_NAMESPACE"
+          value: "kubeaddons"
+        - name: "DEX_SECRET_NAME"
+          value: "dex-kubeaddons"
+        - name: "OPS_PORTAL_NAMESPACE"
+          value: "kubeaddons"
+        - name: "OPS_PORTAL_SECRET_NAME"
+          value: "ops-portal-credentials"
+        - name: "TRAEFIK_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TRAEFIK_SERVICE_NAME"
+          value: "traefik-kubeaddons"

--- a/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-2.yaml
+++ b/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-2.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: traefik-forward-auth
+  namespace: kubeaddons
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.4-2"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: dex
+    - matchLabels:
+        kubeaddons.mesosphere.io/provides: ingresscontroller
+  chartReference:
+    chart: traefik-forward-auth
+    repo: https://mesosphere.github.io/charts/staging
+    version: 0.2.12
+    values: |
+      ---
+      replicaCount: 1
+      image:
+        repository: mesosphere/traefik-forward-auth
+        tag: 1.0.7
+        pullPolicy: IfNotPresent
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      service:
+        type: ClusterIP
+        port: 4181
+      traefikForwardAuth:
+        # oidcUri will be overridden by the init-container
+        oidcUri: "https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex"
+        clientId: traefik-forward-auth
+        clientSecret:
+          valueFrom:
+            secretKeyRef:
+              name: dex-client-secret-traefik-forward-auth
+              key: client_secret
+        cookieSecure: true
+        userCookieName: "konvoy_profile_name"
+        allowedUser:
+          valueFrom:
+            secretKeyRef:
+              name: ops-portal-credentials
+              key: username
+        extraConfig:
+          auth-host = dex-kubeaddons.kubeaddons.svc.cluster.local:8080
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.class: traefik
+          ingress.kubernetes.io/protocol: https
+          traefik.ingress.kubernetes.io/auth-type: forward
+          traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
+          traefik.ingress.kubernetes.io/priority: "1"
+        paths:
+          - /_oauth
+        hosts:
+          - ""
+        tls: []
+      deploymentAnnotations:
+        # The certificate can change because it was rotated or different cluster
+        # DNS name has been set.
+        secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate,dex-kubeaddons"
+      initContainers:
+      # initialize-traefik-forward-auth deploys credentials for use by the proxy
+      - name: initialize-traefik-forward-auth
+        image: mesosphere/kubeaddons-addon-initializer:v0.1.8
+        args: ["traefikforwardauth"]
+        env:
+        - name: "TFA_CONFIGMAP_NAME"
+          value: "traefik-forward-auth-kubeaddons-configmap"
+        - name: "TFA_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TFA_INGRESS_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TFA_INGRESS_SERVICE_NAME"
+          value: "traefik-kubeaddons"


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug 
**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This allows a controlled refresh of secrets for dex and tfa, so the chain works like the following:

opsportal-credentials secret gets update
dex must update its configurations and so reloader triggers a new deployment which creates a new configmap
tfa needs a new configuration to pick up the dex changes so reloader checks the configmap from dex and triggers a new deployment

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-63608
**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [X] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [X] The core changes are covered by tests.
* [X] The documentation is updated where needed.
