### PR TITLE
Add cloudproviders retroactively for traefik

### DIFF
--- a/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-1.yaml
+++ b/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-1.yaml
@@ -9,6 +9,17 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
   requires:
     - matchLabels:
         kubeaddons.mesosphere.io/name: dex

--- a/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-2.yaml
+++ b/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-2.yaml
@@ -9,6 +9,17 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
   requires:
     - matchLabels:
         kubeaddons.mesosphere.io/name: dex

--- a/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-3.yaml
+++ b/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-3.yaml
@@ -9,6 +9,17 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
   requires:
     - matchLabels:
         kubeaddons.mesosphere.io/name: dex

--- a/addons/traefik/1.7.x/traefik-1.yaml
+++ b/addons/traefik/1.7.x/traefik-1.yaml
@@ -18,6 +18,17 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
   requires:
     - matchLabels:
         kubeaddons.mesosphere.io/name: cert-manager

--- a/addons/traefik/1.7.x/traefik-2.yaml
+++ b/addons/traefik/1.7.x/traefik-2.yaml
@@ -18,6 +18,17 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
   requires:
     - matchLabels:
         kubeaddons.mesosphere.io/name: cert-manager

--- a/addons/traefik/1.7.x/traefik-3.yaml
+++ b/addons/traefik/1.7.x/traefik-3.yaml
@@ -15,6 +15,17 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
   requires:
     - matchLabels:
         kubeaddons.mesosphere.io/name: cert-manager

--- a/addons/traefik/1.7.x/traefik-4.yaml
+++ b/addons/traefik/1.7.x/traefik-4.yaml
@@ -15,6 +15,17 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
   requires:
     - matchLabels:
         kubeaddons.mesosphere.io/name: cert-manager

--- a/addons/traefik/1.7.x/traefik-5.yaml
+++ b/addons/traefik/1.7.x/traefik-5.yaml
@@ -15,6 +15,17 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
   requires:
     - matchLabels:
         kubeaddons.mesosphere.io/name: cert-manager


### PR DESCRIPTION
This retroactive (and backwards compatibly) fixes a bug in kubernetes-base-addons where traefik was not declared for all cloud providers.