### PR TITLE
dex: bump Dex to v2.22.0

### DIFF
--- a/addons/dex/2.22.x/dex-1.yaml
+++ b/addons/dex/2.22.x/dex-1.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: dex
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: dex
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "2.17.0-2"
+    appversion.kubeaddons.mesosphere.io/dex: "2.17.0"
+    values.chart.helm.kubeaddons.mesosphere.io/dex: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/dex/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/provides: ingresscontroller
+  chartReference:
+    chart: dex
+    repo: https://mesosphere.github.io/charts/stable
+    version: 1.6.13
+    values: |
+      ---
+      # Temporarily we're going to use our custom built container. Documentation
+      # for how to build a new version: https://github.com/mesosphere/dex/blob/v2.17.0-mesosphere/README.mesosphere.md
+      image: mesosphere/dex
+      imageTag: v2.17.0-25-g5597-mesosphere
+      resources:
+        requests:
+          cpu: 100m
+          memory: 50Mi
+      deploymentAnnotations:
+        # The certificate can change because it was rotated or different cluster
+        # DNS name has been set.
+        secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate,ops-portal-credentials"
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.class: traefik
+          ingress.kubernetes.io/protocol: https
+        path: /dex
+        hosts:
+          - ""
+      ports:
+        - name: https
+          containerPort: 8080
+          protocol: TCP
+      certs:
+        web:
+          create: false
+          secret:
+            tlsName: dex
+      config:
+        issuer: https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex
+        frontend:
+          issuer: Kubernetes
+          theme: d2iq
+        storage:
+          type: kubernetes
+          config:
+            inCluster: true
+        logger:
+          level: debug
+        web:
+          http: 127.0.0.1:8081
+          https: 0.0.0.0:8080
+          tlsCert: /etc/dex/tls/https/server/tls.crt
+          tlsKey: /etc/dex/tls/https/server/tls.key
+        grpc:
+          addr: 0.0.0.0:5000
+          tlsCert: /etc/dex/tls/grpc/server/tls.crt
+          tlsKey: /etc/dex/tls/grpc/server/tls.key
+          tlsClientCA: /etc/dex/tls/grpc/ca/tls.crt
+        oauth2:
+          skipApprovalScreen: true
+        staticClients:
+        # `redirectURIs` and `secret` values are modified in `configureDexStaticClients`
+        - id: kube-apiserver
+          # This `id` must by in sync with `dex-k8s-authenticator.yaml` value as well as
+          # kube-apiserver flag `oidc-client-id`.
+          name: 'Kubernetes CLI authenticator'
+          redirectURIs:
+            - 'https://PUBLIC.URI/token/callback/kubernetes-cluster'
+            - 'https://PUBLIC.URI/token/callback'
+        - id: traefik-forward-auth
+          name: 'Ops Portal authenticator'
+          redirectURIs:
+            - 'https://PUBLIC.URI/_oauth'
+      initContainers:
+      - name: initialize-dex
+        image: mesosphere/kubeaddons-addon-initializer:v0.1.7
+        args: ["dex"]
+        env:
+        - name: "DEX_NAMESPACE"
+          value: "kubeaddons"
+        - name: "DEX_SECRET_NAME"
+          value: "dex-kubeaddons"
+        - name: "OPS_PORTAL_NAMESPACE"
+          value: "kubeaddons"
+        - name: "OPS_PORTAL_SECRET_NAME"
+          value: "ops-portal-credentials"
+        - name: "TRAEFIK_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TRAEFIK_SERVICE_NAME"
+          value: "traefik-kubeaddons"

--- a/addons/dex/2.22.x/dex-1.yaml
+++ b/addons/dex/2.22.x/dex-1.yaml
@@ -7,9 +7,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dex
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "2.17.0-2"
-    appversion.kubeaddons.mesosphere.io/dex: "2.17.0"
-    values.chart.helm.kubeaddons.mesosphere.io/dex: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/dex/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "2.22.0-1"
+    appversion.kubeaddons.mesosphere.io/dex: "2.22.0"
+    values.chart.helm.kubeaddons.mesosphere.io/dex: "https://raw.githubusercontent.com/mesosphere/charts/e9a641f07194fce82acbda71b03f83c448c7092d/stable/dex/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -30,13 +30,13 @@ spec:
   chartReference:
     chart: dex
     repo: https://mesosphere.github.io/charts/stable
-    version: 1.6.13
+    version: 2.8.0
     values: |
       ---
       # Temporarily we're going to use our custom built container. Documentation
       # for how to build a new version: https://github.com/mesosphere/dex/blob/v2.17.0-mesosphere/README.mesosphere.md
       image: mesosphere/dex
-      imageTag: v2.17.0-25-g5597-mesosphere
+      imageTag: v2.22.0-2-g3657-d2iq
       resources:
         requests:
           cpu: 100m
@@ -53,10 +53,10 @@ spec:
         path: /dex
         hosts:
           - ""
+      https: true
       ports:
-        - name: https
+        web:
           containerPort: 8080
-          protocol: TCP
       certs:
         web:
           create: false
@@ -74,12 +74,11 @@ spec:
         logger:
           level: debug
         web:
-          http: 127.0.0.1:8081
-          https: 0.0.0.0:8080
+          address: 0.0.0.0
           tlsCert: /etc/dex/tls/https/server/tls.crt
           tlsKey: /etc/dex/tls/https/server/tls.key
         grpc:
-          addr: 0.0.0.0:5000
+          address: 0.0.0.0
           tlsCert: /etc/dex/tls/grpc/server/tls.crt
           tlsKey: /etc/dex/tls/grpc/server/tls.key
           tlsClientCA: /etc/dex/tls/grpc/ca/tls.crt


### PR DESCRIPTION
**What type of PR is this?**

Chore

**What this PR does/ why we need it**:

Bump Dex to v2.22.0. This version supports groups claims for OIDC connectors (e.g., Onelogin/Google).

Tested with konvoy using this branch.

**Which issue(s) this PR fixes**:

No issue.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
dex: upgrade Dex to v2.22.0, which supports groups claims for OIDC connectors.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
