### PR TITLE
Introduce Dispatch to Kubeaddons.

### DIFF
--- a/Dispatchfile
+++ b/Dispatchfile
@@ -1,0 +1,29 @@
+#!starlark
+
+gitResource("src-git", url = "$(context.git.url)", revision = "$(context.git.commit)")
+
+def secretVar(name, key):
+    return k8s.corev1.EnvVarSource(secretKeyRef = k8s.corev1.SecretKeySelector(
+        localObjectReference = k8s.corev1.LocalObjectReference(name=name),
+        key = key))
+
+dindTask("dispatch-integration-test",
+         inputs = ["src-git"],
+         steps = [
+             v1.Container(
+                 name="fetch-master",
+                 image = "mesosphere/dispatch-dind:v0.5.2",
+                 workingDir="/workspace/src-git",
+                 args=["git", "fetch", "origin", "master"]),
+             v1.Container(
+                 name = "dispatch-integration-test",
+                 image = "mesosphere/kubeaddons-ci:dispatch",
+                 command = ["make","test"],
+                 workingDir = "/workspace/src-git",
+                 env = [k8s.corev1.EnvVar(name = "DISPATCH_CI", value = "true"),
+                        k8s.corev1.EnvVar(name = "SSH_KEY_BASE64",
+                                          valueFrom = secretVar("d2iq-dispatch-git-ssh-base64",
+                                                                "ssh-privatekey-base64"))])])
+
+action(tasks = ["dispatch-integration-test"], on = pullRequest())
+action(tasks = ["dispatch-integration-test"], on = pullRequest(chatops = ["test"]))

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+SHELL := /bin/bash -euo pipefail
+
+export GO111MODULE := on
+export ADDON_TESTS_PER_ADDON_WAIT_DURATION := 10m
+export GIT_TERMINAL_PROMPT := 1
+export ADDON_TESTS_SETUP_WAIT_DURATION := 30m
+export GOPRIVATE := github.com/mesosphere/kubeaddons
+
+
+.DEFAULT_GOAL := test
+
+.PHONY: set-git-ssh
+set-git-ssh:
+ifdef DISPATCH_CI
+	./scripts/ci/setup_ssh.sh
+endif
+
+.PHONY: test
+test: set-git-ssh
+	cd test && git fetch; \
+	for g in $(shell cd test && go run scripts/test-wrapper.go); do \
+		go test -timeout 30m -race -v -run $$g; \
+	done

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ Some supported releases are supported via the terms of support for some other KS
 
 For all other non-official releases, make sure your tag and description are distinctly different from the official release pattern, explain the purpose of your release, and mark is as a `pre-release`.
 
+### Testing
+
+The test suite can be exercised locally by running
+
+    make test
+
+
+Pull Requests against this repo is tested by Teamcity and Dispatch. 
+Dispatchfile defines the config and exercises the test in the Makefile.
+
 ## Contributing
 
 See our [Contributing Documentation](CONTRIBUTING.md).

--- a/scripts/ci/setup_ssh.sh
+++ b/scripts/ci/setup_ssh.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# NOTE: this script was originally created to be used by dispatch CI runs
+set -euxo pipefail
+
+if test -z "git config user.email"; then
+    git config user.email "ci@mesosphere.com";
+fi
+
+if test -z "git config user.name"; then
+    git config user.name "CI";
+fi
+
+# Setup git
+# Replace https://github.com/ with "git@github.com:" in ~/.gitconfig
+
+git config --global url.git@github.com:.insteadOf https://github.com/
+
+# Steps to make sure go mod will download from private git repositories.
+
+# add SSH_KEY to the ssh-agent
+# SSH_KEY_BASE64 is provided by Dispatch.
+
+eval "$(ssh-agent -s)";
+mkdir /root/.ssh;
+echo $SSH_KEY_BASE64 |  tr -d "[:space:]" | base64 -d | install -b -m 600 /dev/stdin /root/.ssh/id_rsa
+
+ssh-add /root/.ssh/id_rsa;
+
+# trust github.com
+ssh-keyscan github.com >> /root/.ssh/known_hosts;


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What this PR does/ why we need it**:

Enables Dispatch CI to Kubeaddons


**Which issue(s) this PR fixes**:

* https://jira.d2iq.com/browse/D2IQ-61688 - Enable kubernetes-base-addons CI to run on Dispatch

**Special notes for your reviewer**:

* `mesosphere/kubeaddons-ci:dispatch` is a special image that includes kubeaddons-ci:latest and bits for Dispatch. The Dockerfile will be linked. (The docker file: https://github.com/mesosphere/kubeaddons/pull/747) 

* It is a limitation in dispatch to require a special dind image. The goal is to improve dispatch's `dind` image to support any docker image like `kubeaddons-ci:latest` which is used by Kubernetes CI.

* `GITHUB_TOKEN` is an Opaque secret providing github token. It should he a mesosphere ci token that we want to use for kubernetes ci project.



**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [x] The documentation is updated where needed.
