### PR TITLE
nfs: Added NFS Server Provisioner addon.

### DIFF
--- a/addons/nfsserverprovisioner/2.3.x/nfsserverprovisioner-1.yaml
+++ b/addons/nfsserverprovisioner/2.3.x/nfsserverprovisioner-1.yaml
@@ -1,0 +1,30 @@
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  annotations:
+    appversion.kubeaddons.mesosphere.io/nfs-server-provisioner: 2.3.0
+    catalog.kubeaddons.mesosphere.io/addon-revision: 0.6.0-1
+  labels:
+    kubeaddons.mesosphere.io/name: nfsserverprovisioner
+  name: nfsserverprovisioner
+  namespace: kubeaddons
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  chartReference:
+    chart: nfs-server-provisioner
+    repo: https://mesosphere.github.io/charts/staging
+    version: 0.6.0
+    values: |
+      persistence:
+        enabled: true
+        size: 100Gi
+      storageClass:
+        name: nfsserverprovisioner
+      resources:
+        limits:
+           cpu: 1000m
+           memory: 1024Mi
+        requests:
+           cpu: 50m
+           memory: 256Mi

--- a/addons/nfsserverprovisioner/2.3.x/nfsserverprovisioner-1.yaml
+++ b/addons/nfsserverprovisioner/2.3.x/nfsserverprovisioner-1.yaml
@@ -3,7 +3,7 @@ kind: Addon
 metadata:
   annotations:
     appversion.kubeaddons.mesosphere.io/nfs-server-provisioner: 2.3.0
-    catalog.kubeaddons.mesosphere.io/addon-revision: 0.6.0-1
+    catalog.kubeaddons.mesosphere.io/addon-revision: 2.3.0-1
   labels:
     kubeaddons.mesosphere.io/name: nfsserverprovisioner
   name: nfsserverprovisioner

--- a/addons/nfsserverprovisioner/2.3.x/nfsserverprovisioner-1.yaml
+++ b/addons/nfsserverprovisioner/2.3.x/nfsserverprovisioner-1.yaml
@@ -11,6 +11,15 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: false
+    - name: azure
+      enabled: false
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: false
   chartReference:
     chart: nfs-server-provisioner
     repo: https://mesosphere.github.io/charts/staging

--- a/addons/nfsserverprovisioner/2.3.x/nfsserverprovisioner-1.yaml
+++ b/addons/nfsserverprovisioner/2.3.x/nfsserverprovisioner-1.yaml
@@ -1,11 +1,13 @@
 apiVersion: kubeaddons.mesosphere.io/v1beta1
-kind: Addon
+kind: ClusterAddon
 metadata:
   annotations:
     appversion.kubeaddons.mesosphere.io/nfs-server-provisioner: 2.3.0
     catalog.kubeaddons.mesosphere.io/addon-revision: 2.3.0-1
+    values.chart.helm.kubeaddons.mesosphere.io/awsebscsiprovisioner: "https://raw.githubusercontent.com/mesosphere/charts/master/staging/nfs-server-provisioner/values.yaml"
   labels:
     kubeaddons.mesosphere.io/name: nfsserverprovisioner
+    kubeaddons.mesosphere.io/provides: storageclass
   name: nfsserverprovisioner
   namespace: kubeaddons
 spec:
@@ -31,9 +33,6 @@ spec:
       storageClass:
         name: nfsserverprovisioner
       resources:
-        limits:
-           cpu: 1000m
-           memory: 1024Mi
         requests:
            cpu: 50m
            memory: 256Mi

--- a/test/addons_test.go
+++ b/test/addons_test.go
@@ -123,6 +123,12 @@ func TestLocalVolumeProvisionerGroup(t *testing.T) {
 	}
 }
 
+func TestNfsGroup(t *testing.T) {
+	if err := testgroup(t, "nfs"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // -----------------------------------------------------------------------------
 // Private Functions
 // -----------------------------------------------------------------------------

--- a/test/addons_test.go
+++ b/test/addons_test.go
@@ -123,8 +123,8 @@ func TestLocalVolumeProvisionerGroup(t *testing.T) {
 	}
 }
 
-func TestNfsGroup(t *testing.T) {
-	if err := testgroup(t, "nfs"); err != nil {
+func TestNfsServerProvisionerGroup(t *testing.T) {
+	if err := testgroup(t, "nfsserverprovisioner"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/test/groups.yaml
+++ b/test/groups.yaml
@@ -92,12 +92,12 @@ localvolumeprovisioner:
     - "localvolumeprovisioner"
 
 # ------------------------------------------------------------------------------
-# Nfs
+# NFS Server Provisioner
 #
-# All Nfs related addons should be tested as a part of this group
+# All NFS Server Provisioner related addons should be tested as a part of this group
 # ------------------------------------------------------------------------------
-nfs:
-    - "nfs"
+nfsserverprovisioner:
+    - "nfsserverprovisioner"
 
 # ------------------------------------------------------------------------------
 # Disabled

--- a/test/groups.yaml
+++ b/test/groups.yaml
@@ -92,6 +92,14 @@ localvolumeprovisioner:
     - "localvolumeprovisioner"
 
 # ------------------------------------------------------------------------------
+# Nfs
+#
+# All Nfs related addons should be tested as a part of this group
+# ------------------------------------------------------------------------------
+nfs:
+    - "nfs"
+
+# ------------------------------------------------------------------------------
 # Disabled
 #
 # These are Addons which tests are currently disabled for.


### PR DESCRIPTION
**What type of PR is this?**
Feature - Support NFS Server Provisioner as a kubeaddon

**What this PR does/ why we need it**:
This PR adds the nfsserverprovisioner addon. We need it because:

- This addon will be super useful for konvoy users who need RWX PV, especially ML users, given the fact the existing solution like AWS EFS is still inmature.

- This NFS Server Provisioner supports volume dynamic provisioning.

- The NFS server launched by the provisioner can be backed by PVC, and the provisioner can create fine grained NFS shares under the server. This is a good model and users could easily deploy NFS servers on different cloud providers (azure and google cloud), as well as on-prem.

**Which issue(s) this PR fixes**:
[D2IQ-63390](https://jira.d2iq.com/browse/D2IQ-63390)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Added the NFS Server Provisioner which supports ReadWriteMany Persistent Volume, with PV dynamic provisioning supported.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
