### PR TITLE
fix: run all tests when on Addon has been modified

### DIFF
--- a/test/scripts/test-wrapper.go
+++ b/test/scripts/test-wrapper.go
@@ -14,7 +14,6 @@ import (
 
 type groupName string
 type addonName string
-type groups map[groupName][]addonName
 
 var re = regexp.MustCompile(`^addons/([a-z]+)/?`)
 
@@ -65,12 +64,20 @@ func getGroupsToTest(modifiedAddons []addonName) ([]groupName, error) {
 		return nil, err
 	}
 
-	g := make(groups)
+	g := make(map[groupName][]addonName)
 	if err := yaml.Unmarshal(b, &g); err != nil {
 		return nil, err
 	}
 
 	testGroups := make([]groupName, 0)
+	// if no Addon has been modified, return all existing groups
+	if len(modifiedAddons) == 0 {
+		for group, _ := range g {
+			testGroups = append(testGroups, group)
+		}
+		return testGroups, nil
+	}
+
 	for _, modifiedAddonName := range modifiedAddons {
 		for group, addons := range g {
 			for _, name := range addons {


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Whenever a change not related to an Addon is pushed to kubernetes-base-addons, CI checks will fail (see https://github.com/mesosphere/kubernetes-base-addons/pull/155 for an example case).

But if we're bumping dependencies or changing test code we actually want to run all the tests.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-64683

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
