### PR TITLE
nvidia: Bumped the nvidia chart to 0.3.3 (#160)

### DIFF
--- a/addons/nvidia/0.2.x/nvidia-4.yaml
+++ b/addons/nvidia/0.2.x/nvidia-4.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: nvidia
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: nvidia
+    kubeaddons.mesosphere.io/provides: nvidia
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.2.0-4"
+    appversion.kubeaddons.mesosphere.io/nvidia: "0.2.0"
+    values.chart.helm.kubeaddons.mesosphere.io/nvidia: "https://raw.githubusercontent.com/mesosphere/charts/master/staging/nvidia/values.yaml"
+    helmv2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=0.4.0", "strategy": "delete"}]'
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: false
+    - name: azure
+      enabled: false
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: false
+  chartReference:
+    chart: nvidia
+    repo: https://mesosphere.github.io/charts/staging
+    version: 0.3.3
+    values: |
+      ---
+      grafana:
+        enabled: true
+      nvidia-dcgm-exporter:
+        enabled: true
+        nodeSelector:
+          konvoy.mesosphere.com/gpu-provider: NVIDIA
+        initContainers:
+        - name: init-wait
+          image: busybox
+          command: ['sh', '-c', 'sleep 200']
+      nvidia-device-plugin:
+        enabled: true
+        resources:
+          limits:
+             cpu: 200m
+             memory: 128Mi
+          requests:
+             cpu: 100m
+             memory: 128Mi
+        nodeSelector:
+          konvoy.mesosphere.com/gpu-provider: NVIDIA
+        initContainers:
+        - name: init-wait
+          image: busybox
+          command: ['sh', '-c', 'sleep 180']
+      nvidia-driver:
+        enabled: true
+        image:
+          tag: "418.87.01-centos7"
+        resources:
+          requests:
+             cpu: 500m
+             memory: 512Mi
+        nodeSelector:
+          konvoy.mesosphere.com/gpu-provider: NVIDIA


### PR DESCRIPTION
Bumped the nvidia chart to 0.3.3 which includes the redundant vault repo fix

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore:  cherry-pick from master for fix of the nvidia addon

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
