### PR TITLE
Velero refactor

### DIFF
--- a/addons/traefik/1.7.x/traefik-7.yaml
+++ b/addons/traefik/1.7.x/traefik-7.yaml
@@ -7,11 +7,11 @@ metadata:
     kubeaddons.mesosphere.io/name: traefik
     kubeaddons.mesosphere.io/provides: ingresscontroller
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.7.2-6"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.7.12-7"
     appversion.kubeaddons.mesosphere.io/traefik: "1.7.12"
     endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
     docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/v1.7"
-    values.chart.helm.kubeaddons.mesosphere.io/traefik: "https://raw.githubusercontent.com/mesosphere/charts/5529163bb54ab1b951ffa2eaa60957722bd617db/staging/traefik/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/traefik: "https://raw.githubusercontent.com/mesosphere/charts/16d32f6c23e14cc98f4c44519cfd5382af092b04/staging/traefik/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -21,7 +21,7 @@ spec:
   chartReference:
     chart: traefik
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.72.15
+    version: 1.72.16
     values: |
       ---
       replicas: 2
@@ -95,3 +95,15 @@ spec:
           value: "clusterHostname"
 
       initCertJobImage: mesosphere/kubeaddons-addon-initializer:v0.1.5
+      extraServicePorts:
+        - name: velero-minio
+          port: 9000
+          protocol: TCP
+          targetPort: 9000
+      extraConfigEntrypoints: |
+        [entryPoints.velero-minio]
+        address = ":9000"
+          [entryPoints.velero-minio.tls]
+          [entryPoints.velero-minio.tls.defaultCertificate]
+          certFile = "/ssl/tls.crt"
+          keyFile = "/ssl/tls.key"

--- a/addons/traefik/1.7.x/traefik-7.yaml
+++ b/addons/traefik/1.7.x/traefik-7.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: traefik
+  labels:
+    kubeaddons.mesosphere.io/name: traefik
+    kubeaddons.mesosphere.io/provides: ingresscontroller
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.7.2-6"
+    appversion.kubeaddons.mesosphere.io/traefik: "1.7.12"
+    endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
+    docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/v1.7"
+    values.chart.helm.kubeaddons.mesosphere.io/traefik: "https://raw.githubusercontent.com/mesosphere/charts/5529163bb54ab1b951ffa2eaa60957722bd617db/staging/traefik/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: cert-manager
+  chartReference:
+    chart: traefik
+    repo: https://mesosphere.github.io/charts/staging
+    version: 1.72.15
+    values: |
+      ---
+      replicas: 2
+      service:
+        labels:
+          servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
+      resources:
+        limits:
+          cpu: 1000m
+        requests:
+          cpu: 500m
+      rbac:
+        enabled: true
+      metrics:
+        prometheus:
+          enabled: true
+      dashboard:
+        enabled: true
+        domain: ""
+        serviceType: ClusterIP
+        ingress:
+          path: /ops/portal/traefik
+          annotations:
+            kubernetes.io/ingress.class: traefik
+            traefik.frontend.rule.type: PathPrefixStrip
+            traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User,Authorization,Impersonate-User,Impersonate-Group
+            traefik.ingress.kubernetes.io/auth-type: forward
+            traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
+            traefik.ingress.kubernetes.io/priority: "2"
+      kubernetes:
+        ingressEndpoint:
+          publishedService: "kubeaddons/traefik-kubeaddons"
+      ssl:
+        enabled: true
+        enforced: true
+        # TODO: This comment is no longer true.
+        # dex service is exposed with TLS certificate signed by self signed root
+        # Dex CA certificate. It is not clear if traefik supports configuring
+        # trusted certificates per backend. This should be investiaged in a
+        # separate issue.
+        # See: https://jira.mesosphere.com/browse/DCOS-56033
+        insecureSkipVerify: true
+        # We use cert-manager to automate certificate management thus we
+        # do not need the default cert secret.
+        useCertManager: true
+      deploymentAnnotations:
+        # Watching this CM will trigger traefik init container that updates certificate
+        # object with new DNS names. That will cascade secret update which will trigger
+        # another reload.
+        configmap.reloader.stakater.com/reload: konvoyconfig-kubeaddons
+        secret.reloader.stakater.com/reload: traefik-kubeaddons-certificate
+
+      initContainers:
+      - name: initialize-traefik-certificate
+        image: mesosphere/kubeaddons-addon-initializer:v0.1.5
+        args: ["traefik"]
+        env:
+        - name: "TRAEFIK_INGRESS_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TRAEFIK_INGRESS_SERVICE_NAME"
+          value: "traefik-kubeaddons"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_NAME"
+          value: "traefik-kubeaddons"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_ISSUER"
+          value: "kubernetes-ca"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_SECRET_NAME"
+          value: "traefik-kubeaddons-certificate"
+        - name: "TRAEFIK_KONVOY_ADDONS_CONFIG_MAP"
+          value: "konvoyconfig-kubeaddons"
+        - name: "TRAEFIK_CLUSTER_HOSTNAME_KEY"
+          value: "clusterHostname"
+
+      initCertJobImage: mesosphere/kubeaddons-addon-initializer:v0.1.5

--- a/addons/velero/1.0.x/velero-2.yaml
+++ b/addons/velero/1.0.x/velero-2.yaml
@@ -1,0 +1,79 @@
+---
+# ------------------------------------------------------------------------------
+# Velero
+#
+#
+# Velero is an open source backup and migration tool for Kubernetes.
+# See more about Velero at:
+#
+# * https://velero.io/
+# * https://github.com/heptio/velero
+# * https://github.com/helm/charts/tree/master/stable/velero
+#
+#
+# Implementation
+#
+#
+# Our implementation of Velero currently supports S3 backends for storage, and by default if no configuration overrides are
+# provided to point it at a backend other than the default, we will create and manage a distributed Minio (https://min.io/)
+# cluster which uses the default storage class for the cluster to maintain the backups.
+#
+#
+# WARNING: using the default (fallback) backend is for testing purposes only and should not be used in production.
+# ------------------------------------------------------------------------------
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: velero
+  labels:
+    kubeaddons.mesosphere.io/name: velero
+    # TODO: we're temporarily supporting dependency on an existing default storage class
+    # on the cluster, this hack will trigger re-queue on Addons until one exists.
+    kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.1-1"
+    values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/helm/charts/39524419882dcf3d1a053711ac242c280923a094/stable/velero/values.yaml"
+spec:
+  namespace: velero
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: none
+      enabled: true
+  chartReference:
+    chart: velero
+    repo: https://mesosphere.github.io/charts/staging
+    version: 2.2.11
+    values: |
+      ---
+      configuration:
+        provider: "aws"
+        backupStorageLocation:
+          name: "aws"
+          bucket: "velero"
+          config:
+            region: "fallback"     # enables non-production fallback minio backend
+            s3ForcePathStyle: true # allows usage of fallback backend
+            s3Url: http://minio.velero.svc:9000
+        volumeSnapshotLocation:
+          name: "aws"
+          config:
+            region: "fallback"
+      credentials:
+        secretContents:
+          cloud: "placeholder"
+      schedules:
+        default:
+          schedule: "0 0 * * *"
+      metrics:
+        enabled: true
+        service:
+          labels:
+            servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
+      minioBackend: true

--- a/addons/velero/1.0.x/velero-2.yaml
+++ b/addons/velero/1.0.x/velero-2.yaml
@@ -31,8 +31,8 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.1-1"
-    values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/helm/charts/39524419882dcf3d1a053711ac242c280923a094/stable/velero/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.1-2"
+    values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/mesosphere/charts/16d32f6c23e14cc98f4c44519cfd5382af092b04/staging/velero/values.yaml"
 spec:
   namespace: velero
   kubernetes:
@@ -46,10 +46,13 @@ spec:
       enabled: true
     - name: none
       enabled: true
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/provides: ingresscontroller
   chartReference:
     chart: velero
     repo: https://mesosphere.github.io/charts/staging
-    version: 2.2.11
+    version: 3.0.0
     values: |
       ---
       configuration:
@@ -76,4 +79,38 @@ spec:
         service:
           labels:
             servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
+      initContainers:
+      - name: initialize-velero
+        image: mesosphere/kubeaddons-addon-initializer:v0.2.5
+        args: ["velero"]
+        env:
+        - name: "VELERO_MINIO_FALLBACK_SECRET_NAME"
+          value: "velero-kubeaddons"
       minioBackend: true
+      minio:
+        mode: distributed
+        defaultBucket:
+          enabled: true
+          name: velero
+        bucketRoot: "/data"
+        existingSecret: minio-creds-secret
+        livenessProbe:
+          initialDelaySeconds: 120
+          periodSeconds: 20
+        resources:
+          requests:
+            memory: 256Mi
+            cpu: 250m
+          limits:
+            memory: 512Mi
+            cpu: 750m
+        persistence:
+          volumeTemplatePrefix: data
+        statefulSetNameOverride: minio
+        ingress:
+          enabled: true
+          hosts:
+          - ""
+          annotations:
+            kubernetes.io/ingress.class: traefik
+            traefik.ingress.kubernetes.io/frontend-entry-points: velero-minio

--- a/addons/velero/1.0.x/velero-2.yaml
+++ b/addons/velero/1.0.x/velero-2.yaml
@@ -33,6 +33,7 @@ metadata:
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.1-2"
     values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/mesosphere/charts/16d32f6c23e14cc98f4c44519cfd5382af092b04/staging/velero/values.yaml"
+    helmv2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<3.0.0", "strategy": "delete"}]'
 spec:
   namespace: velero
   kubernetes:

--- a/test/groups.yaml
+++ b/test/groups.yaml
@@ -24,7 +24,10 @@ general:
 # Addons related to backup and restore tools are tested as part of this group.
 # ------------------------------------------------------------------------------
 backups:
+    - "konvoyconfig"
     - "metallb"
+    - "traefik"
+    - "cert-manager"
     - "velero"
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

This changed the way we deploy Minio bundled with Velero. Instead of using Minio Operator and install a Minio instance in init container, we switched to use Minio helm chart. We also choose to expose Minio through Traefik ingress (on a separate entry point), instead of create another Service type LB and handling certificates manually in the init container.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-65023

**Special notes for your reviewer**:

Tested this manually for both fresh install and upgrade:

**Fresh install** `konvoy up` with this KBA branch

Result: `konvoy up` finished successfully. Issued command `velero backup get`, was able to see the backup. Then issued command `velero backend downlaod <backup> --insecure-skip-tls-verify`, and confirmed that the backup is downloaded.

**Upgrade from KBA `stable-1.16-1.2.0`**. `konvoy up` with KBA `stable-1.16-1.2.0`, modify `cluster.yaml` to use this branch. `konvoy deploy addons`. Issued command `velero backup get`, was able to see the backup. Then issued command `velero backend downlaod <backup> --insecure-skip-tls-verify`, and confirmed that the backup is downloaded.

Running konvoy e2e with this branch of KBA as the default here:
https://github.com/mesosphere/konvoy/pull/1323

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
velero: switch to use minio helm chart (instead of operator) for backup storage. This allow users to install their own minio operator for general purpose object storage.
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
