### PR TITLE
dka: bump dka to 1.1.15

### DIFF
--- a/addons/dex-k8s-authenticator/1.1.x/dex-k8s-authenticator-4.yaml
+++ b/addons/dex-k8s-authenticator/1.1.x/dex-k8s-authenticator-4.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: dex-k8s-authenticator
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: dex-k8s-authenticator
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.1-3"
+    appversion.kubeaddons.mesosphere.io/dex-k8s-authenticator: "v1.1.1"
+    values.chart.helm.kubeaddons.mesosphere.io/dex-k8s-authenticator: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/staging/dex-k8s-authenticator/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: dex
+    - matchLabels:
+        kubeaddons.mesosphere.io/provides: ingresscontroller
+  chartReference:
+    chart: dex-k8s-authenticator
+    repo: https://mesosphere.github.io/charts/staging
+    version: 1.1.14
+    values: |
+      ---
+      image:
+        repository: mesosphere/dex-k8s-authenticator
+        tag: v1.1.0-43-gb097-d2iq
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.class: traefik
+        path: /token
+        hosts:
+          - ""
+      dexK8sAuthenticator:
+        #logoUrl: http://<path-to-your-logo.png>
+        #tlsCert: /path/to/dex-client.crt
+        #tlsKey: /path/to/dex-client.key
+        clusters:
+        - name: kubernetes-cluster
+          short_description: "Kubernetes cluster"
+          description: "Kubernetes cluster authenticator"
+          # client_secret: value is generated automatically via initContainers
+          client_id: kube-apiserver
+          issuer: https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex
+          # This URI is just a placeholder and it will be replaced during initContainers
+          # with a URL pointing to the traefik ingress public load balancer.
+          redirect_uri: https://dex-k8s-authenticator-kubeaddons.kubeaddons.svc.cluster.local:5555/token/callback/kubernetes-cluster
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      deploymentAnnotations:
+        # The certificate can change because it was rotated or different cluster
+        # DNS name has been set.
+        secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate"
+        configmap.reloader.stakater.com/reload: "dex-k8s-authenticator-kubeaddons"
+      initContainers:
+      - name: initialize-dka-config
+        image: mesosphere/kubeaddons-addon-initializer:v0.2.1
+        args: ["dexK8sAuthenticator"]
+        env:
+        - name: "DKA_CONFIGMAP_NAME"
+          value: "dex-k8s-authenticator-kubeaddons"
+        - name: "DKA_NAMESPACE"
+          value: "kubeaddons"
+        - name: "DKA_INGRESS_NAMESPACE"
+          value: "kubeaddons"
+        - name: "DKA_INGRESS_SERVICE_NAME"
+          value: "traefik-kubeaddons"
+        - name: "DKA_WEB_PREFIX_PATH"
+          value: "/token"

--- a/addons/dex-k8s-authenticator/1.1.x/dex-k8s-authenticator-4.yaml
+++ b/addons/dex-k8s-authenticator/1.1.x/dex-k8s-authenticator-4.yaml
@@ -7,9 +7,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dex-k8s-authenticator
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.1-3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.1-4"
     appversion.kubeaddons.mesosphere.io/dex-k8s-authenticator: "v1.1.1"
-    values.chart.helm.kubeaddons.mesosphere.io/dex-k8s-authenticator: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/staging/dex-k8s-authenticator/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/dex-k8s-authenticator: "https://raw.githubusercontent.com/mesosphere/charts/f44c645c6bc843b254bb0f4f97d516f2cfee4707/staging/dex-k8s-authenticator/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -32,7 +32,7 @@ spec:
   chartReference:
     chart: dex-k8s-authenticator
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.1.14
+    version: 1.1.15
     values: |
       ---
       image:
@@ -70,7 +70,7 @@ spec:
         configmap.reloader.stakater.com/reload: "dex-k8s-authenticator-kubeaddons"
       initContainers:
       - name: initialize-dka-config
-        image: mesosphere/kubeaddons-addon-initializer:v0.2.1
+        image: mesosphere/kubeaddons-addon-initializer:v0.2.7
         args: ["dexK8sAuthenticator"]
         env:
         - name: "DKA_CONFIGMAP_NAME"


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Allow DKA to use system default CA.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-65233

**Special notes for your reviewer**:

Manually tested this with this KBA branch:
1. First `konvoy up`
2. Create Route53 record to create an CNAME `jie.ksphere-platform.d2iq.cloud` for the ingress ELB host
3. Modify `cluster.yaml` and set `konvoyconfig.config.clusterHostname` to `jie.ksphere-platform.d2iq.cloud`
4. `konvoy up`
5. Apply the following yamls to let cert-manager issue a valid Let's Encrypt certificate
```yaml
apiVersion: certmanager.k8s.io/v1alpha1
kind: ClusterIssuer
metadata:
  name: letsencrypt
spec:
  acme:
    # You must replace this email address with your own.
    # Let's Encrypt will use this to contact you about expiring
    # certificates, and issues related to your account.
    email: jie@d2iq.com
    server: https://acme-v02.api.letsencrypt.org/directory
    privateKeySecretRef:
      # Secret resource that will be used to store the account's private key.
      name: letsencrypt-private-key
    http01: {}
---
apiVersion: certmanager.k8s.io/v1alpha1
kind: Certificate
metadata:
  name: acme-certs
  namespace: kubeaddons
spec:
  secretName: acme-certs
  issuerRef:
    kind: ClusterIssuer
    name: letsencrypt
  commonName: jie.ksphere-platform.d2iq.cloud
  dnsNames:
  - jie.ksphere-platform.d2iq.cloud
  acme:
    config:
    - http01:
        ingressClass: traefik
      domains:
      - jie.ksphere-platform.d2iq.cloud
```
6. Modify `cluster.yaml` like the following
```yaml
  - name: traefik
      enabled: true
      values:  |
        ssl:
          caSecretName: acme-certs  
  - name: dex-k8s-authenticator                                                                                                                             
      enabled: true                                                                                                                                           
      values: |                                                                                                                                               
        caCerts:                                                                                                                                              
          enabled: true                                                                                                                                       
          useSystemDefault: true
```
7. `konvoy up`
8. Validated the `/token` page.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
dex-k8s-authenticator: allow to use system default CA
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
