### PR TITLE
chore: Bump the traefik chart version from 1.72.16 to 1.72.17.

### DIFF
--- a/addons/traefik/1.7.x/traefik-8.yaml
+++ b/addons/traefik/1.7.x/traefik-8.yaml
@@ -7,11 +7,11 @@ metadata:
     kubeaddons.mesosphere.io/name: traefik
     kubeaddons.mesosphere.io/provides: ingresscontroller
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.7.12-7"
-    appversion.kubeaddons.mesosphere.io/traefik: "1.7.12"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.7.23-8"
+    appversion.kubeaddons.mesosphere.io/traefik: "1.7.23"
     endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
     docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/v1.7"
-    values.chart.helm.kubeaddons.mesosphere.io/traefik: "https://raw.githubusercontent.com/mesosphere/charts/16d32f6c23e14cc98f4c44519cfd5382af092b04/staging/traefik/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/traefik: "https://raw.githubusercontent.com/mesosphere/charts/30cff72975bec6938a9e11f3e9d9b8a49e9f0300/staging/traefik/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -21,7 +21,7 @@ spec:
   chartReference:
     chart: traefik
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.72.16
+    version: 1.72.17
     values: |
       ---
       replicas: 2

--- a/addons/traefik/1.7.x/traefik-8.yaml
+++ b/addons/traefik/1.7.x/traefik-8.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: traefik
+  labels:
+    kubeaddons.mesosphere.io/name: traefik
+    kubeaddons.mesosphere.io/provides: ingresscontroller
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.7.12-7"
+    appversion.kubeaddons.mesosphere.io/traefik: "1.7.12"
+    endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
+    docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/v1.7"
+    values.chart.helm.kubeaddons.mesosphere.io/traefik: "https://raw.githubusercontent.com/mesosphere/charts/16d32f6c23e14cc98f4c44519cfd5382af092b04/staging/traefik/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: cert-manager
+  chartReference:
+    chart: traefik
+    repo: https://mesosphere.github.io/charts/staging
+    version: 1.72.16
+    values: |
+      ---
+      replicas: 2
+      service:
+        labels:
+          servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
+      resources:
+        limits:
+          cpu: 1000m
+        requests:
+          cpu: 500m
+      rbac:
+        enabled: true
+      metrics:
+        prometheus:
+          enabled: true
+      dashboard:
+        enabled: true
+        domain: ""
+        serviceType: ClusterIP
+        ingress:
+          path: /ops/portal/traefik
+          annotations:
+            kubernetes.io/ingress.class: traefik
+            traefik.frontend.rule.type: PathPrefixStrip
+            traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User,Authorization,Impersonate-User,Impersonate-Group
+            traefik.ingress.kubernetes.io/auth-type: forward
+            traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
+            traefik.ingress.kubernetes.io/priority: "2"
+      kubernetes:
+        ingressEndpoint:
+          publishedService: "kubeaddons/traefik-kubeaddons"
+      ssl:
+        enabled: true
+        enforced: true
+        # TODO: This comment is no longer true.
+        # dex service is exposed with TLS certificate signed by self signed root
+        # Dex CA certificate. It is not clear if traefik supports configuring
+        # trusted certificates per backend. This should be investiaged in a
+        # separate issue.
+        # See: https://jira.mesosphere.com/browse/DCOS-56033
+        insecureSkipVerify: true
+        # We use cert-manager to automate certificate management thus we
+        # do not need the default cert secret.
+        useCertManager: true
+      deploymentAnnotations:
+        # Watching this CM will trigger traefik init container that updates certificate
+        # object with new DNS names. That will cascade secret update which will trigger
+        # another reload.
+        configmap.reloader.stakater.com/reload: konvoyconfig-kubeaddons
+        secret.reloader.stakater.com/reload: traefik-kubeaddons-certificate
+
+      initContainers:
+      - name: initialize-traefik-certificate
+        image: mesosphere/kubeaddons-addon-initializer:v0.1.5
+        args: ["traefik"]
+        env:
+        - name: "TRAEFIK_INGRESS_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TRAEFIK_INGRESS_SERVICE_NAME"
+          value: "traefik-kubeaddons"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_NAME"
+          value: "traefik-kubeaddons"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_ISSUER"
+          value: "kubernetes-ca"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_SECRET_NAME"
+          value: "traefik-kubeaddons-certificate"
+        - name: "TRAEFIK_KONVOY_ADDONS_CONFIG_MAP"
+          value: "konvoyconfig-kubeaddons"
+        - name: "TRAEFIK_CLUSTER_HOSTNAME_KEY"
+          value: "clusterHostname"
+
+      initCertJobImage: mesosphere/kubeaddons-addon-initializer:v0.1.5
+      extraServicePorts:
+        - name: velero-minio
+          port: 9000
+          protocol: TCP
+          targetPort: 9000
+      extraConfigEntrypoints: |
+        [entryPoints.velero-minio]
+        address = ":9000"
+          [entryPoints.velero-minio.tls]
+          [entryPoints.velero-minio.tls.defaultCertificate]
+          certFile = "/ssl/tls.crt"
+          keyFile = "/ssl/tls.key"


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->

Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

Bump the traefik chart version from 1.72.16 to 1.72.17.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

https://jira.d2iq.com/browse/D2IQ-62213

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Upgrade Traefik to 1.7.23. This change fixes the ability to access the Kubernetes API server when the connection needs upgraded to SPDY, among other bug fixes. For more details, see https://github.com/mesosphere/charts/pull/514
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
