### PR TITLE
chore(dex, dka): support kubectl token plugin

### DIFF
--- a/addons/dex-k8s-authenticator/1.1.x/dex-k8s-authenticator-5.yaml
+++ b/addons/dex-k8s-authenticator/1.1.x/dex-k8s-authenticator-5.yaml
@@ -37,7 +37,7 @@ spec:
       ---
       image:
         repository: mesosphere/dex-k8s-authenticator
-        tag: v1.1.1-cdee-d2iq
+        tag: v1.1.1-9d39-d2iq
       ingress:
         enabled: true
         annotations:

--- a/addons/dex-k8s-authenticator/1.1.x/dex-k8s-authenticator-5.yaml
+++ b/addons/dex-k8s-authenticator/1.1.x/dex-k8s-authenticator-5.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dex-k8s-authenticator
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.1-4"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.1-5"
     appversion.kubeaddons.mesosphere.io/dex-k8s-authenticator: "v1.1.1"
     values.chart.helm.kubeaddons.mesosphere.io/dex-k8s-authenticator: "https://raw.githubusercontent.com/mesosphere/charts/f44c645c6bc843b254bb0f4f97d516f2cfee4707/staging/dex-k8s-authenticator/values.yaml"
 spec:
@@ -37,7 +37,7 @@ spec:
       ---
       image:
         repository: mesosphere/dex-k8s-authenticator
-        tag: v1.1.0-43-gb097-d2iq
+        tag: v1.1.1-cdee-d2iq
       ingress:
         enabled: true
         annotations:
@@ -49,6 +49,7 @@ spec:
         #logoUrl: http://<path-to-your-logo.png>
         #tlsCert: /path/to/dex-client.crt
         #tlsKey: /path/to/dex-client.key
+        hmac_secret: ""
         clusters:
         - name: kubernetes-cluster
           short_description: "Kubernetes cluster"
@@ -70,7 +71,7 @@ spec:
         configmap.reloader.stakater.com/reload: "dex-k8s-authenticator-kubeaddons"
       initContainers:
       - name: initialize-dka-config
-        image: mesosphere/kubeaddons-addon-initializer:v0.2.7
+        image: mesosphere/kubeaddons-addon-initializer:v0.2.8
         args: ["dexK8sAuthenticator"]
         env:
         - name: "DKA_CONFIGMAP_NAME"

--- a/addons/dex-k8s-authenticator/1.1.x/dex-k8s-authenticator-5.yaml
+++ b/addons/dex-k8s-authenticator/1.1.x/dex-k8s-authenticator-5.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: dex-k8s-authenticator
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: dex-k8s-authenticator
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.1-4"
+    appversion.kubeaddons.mesosphere.io/dex-k8s-authenticator: "v1.1.1"
+    values.chart.helm.kubeaddons.mesosphere.io/dex-k8s-authenticator: "https://raw.githubusercontent.com/mesosphere/charts/f44c645c6bc843b254bb0f4f97d516f2cfee4707/staging/dex-k8s-authenticator/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: dex
+    - matchLabels:
+        kubeaddons.mesosphere.io/provides: ingresscontroller
+  chartReference:
+    chart: dex-k8s-authenticator
+    repo: https://mesosphere.github.io/charts/staging
+    version: 1.1.15
+    values: |
+      ---
+      image:
+        repository: mesosphere/dex-k8s-authenticator
+        tag: v1.1.0-43-gb097-d2iq
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.class: traefik
+        path: /token
+        hosts:
+          - ""
+      dexK8sAuthenticator:
+        #logoUrl: http://<path-to-your-logo.png>
+        #tlsCert: /path/to/dex-client.crt
+        #tlsKey: /path/to/dex-client.key
+        clusters:
+        - name: kubernetes-cluster
+          short_description: "Kubernetes cluster"
+          description: "Kubernetes cluster authenticator"
+          # client_secret: value is generated automatically via initContainers
+          client_id: kube-apiserver
+          issuer: https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex
+          # This URI is just a placeholder and it will be replaced during initContainers
+          # with a URL pointing to the traefik ingress public load balancer.
+          redirect_uri: https://dex-k8s-authenticator-kubeaddons.kubeaddons.svc.cluster.local:5555/token/callback/kubernetes-cluster
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      deploymentAnnotations:
+        # The certificate can change because it was rotated or different cluster
+        # DNS name has been set.
+        secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate"
+        configmap.reloader.stakater.com/reload: "dex-k8s-authenticator-kubeaddons"
+      initContainers:
+      - name: initialize-dka-config
+        image: mesosphere/kubeaddons-addon-initializer:v0.2.7
+        args: ["dexK8sAuthenticator"]
+        env:
+        - name: "DKA_CONFIGMAP_NAME"
+          value: "dex-k8s-authenticator-kubeaddons"
+        - name: "DKA_NAMESPACE"
+          value: "kubeaddons"
+        - name: "DKA_INGRESS_NAMESPACE"
+          value: "kubeaddons"
+        - name: "DKA_INGRESS_SERVICE_NAME"
+          value: "traefik-kubeaddons"
+        - name: "DKA_WEB_PREFIX_PATH"
+          value: "/token"

--- a/addons/dex/2.22.x/dex-5.yaml
+++ b/addons/dex/2.22.x/dex-5.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dex
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "2.22.0-4"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "2.22.0-5"
     appversion.kubeaddons.mesosphere.io/dex: "2.22.0"
     values.chart.helm.kubeaddons.mesosphere.io/dex: "https://raw.githubusercontent.com/mesosphere/charts/a9307cb8667b1601bce2eda3da0be024fd317fad/stable/dex/values.yaml"
 spec:
@@ -93,6 +93,7 @@ spec:
           redirectURIs:
             - 'https://PUBLIC.URI/token/callback/kubernetes-cluster'
             - 'https://PUBLIC.URI/token/callback'
+            - 'https://PUBLIC.URI/token/async/callback'
         - id: traefik-forward-auth
           name: 'Ops Portal authenticator'
           redirectURIs:

--- a/addons/dex/2.22.x/dex-5.yaml
+++ b/addons/dex/2.22.x/dex-5.yaml
@@ -1,0 +1,116 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: dex
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: dex
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "2.22.0-4"
+    appversion.kubeaddons.mesosphere.io/dex: "2.22.0"
+    values.chart.helm.kubeaddons.mesosphere.io/dex: "https://raw.githubusercontent.com/mesosphere/charts/a9307cb8667b1601bce2eda3da0be024fd317fad/stable/dex/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/provides: ingresscontroller
+  chartReference:
+    chart: dex
+    repo: https://mesosphere.github.io/charts/stable
+    version: 2.8.4
+    values: |
+      ---
+      # Temporarily we're going to use our custom built container. Documentation
+      # for how to build a new version: https://github.com/mesosphere/dex/blob/v2.17.0-mesosphere/README.mesosphere.md
+      image: mesosphere/dex
+      imageTag: v2.22.0-2-g3657-d2iq
+      resources:
+        requests:
+          cpu: 100m
+          memory: 50Mi
+      deploymentAnnotations:
+        # The certificate can change because it was rotated or different cluster
+        # DNS name has been set.
+        secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate,ops-portal-credentials"
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.class: traefik
+          ingress.kubernetes.io/protocol: https
+        path: /dex
+        hosts:
+          - ""
+      https: true
+      ports:
+        web:
+          containerPort: 8080
+      certs:
+        web:
+          create: false
+          secret:
+            tlsName: dex
+      config:
+        issuer: https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex
+        frontend:
+          issuer: Kubernetes
+          theme: d2iq
+        storage:
+          type: kubernetes
+          config:
+            inCluster: true
+        logger:
+          level: debug
+        web:
+          address: 0.0.0.0
+          tlsCert: /etc/dex/tls/https/server/tls.crt
+          tlsKey: /etc/dex/tls/https/server/tls.key
+        grpc:
+          address: 0.0.0.0
+          tlsCert: /etc/dex/tls/grpc/server/tls.crt
+          tlsKey: /etc/dex/tls/grpc/server/tls.key
+          tlsClientCA: /etc/dex/tls/grpc/ca/tls.crt
+        oauth2:
+          skipApprovalScreen: true
+        staticClients:
+        # `redirectURIs` and `secret` values are modified in `configureDexStaticClients`
+        - id: kube-apiserver
+          # This `id` must by in sync with `dex-k8s-authenticator.yaml` value as well as
+          # kube-apiserver flag `oidc-client-id`.
+          name: 'Kubernetes CLI authenticator'
+          redirectURIs:
+            - 'https://PUBLIC.URI/token/callback/kubernetes-cluster'
+            - 'https://PUBLIC.URI/token/callback'
+        - id: traefik-forward-auth
+          name: 'Ops Portal authenticator'
+          redirectURIs:
+            - 'https://PUBLIC.URI/_oauth'
+      initContainers:
+      - name: initialize-dex
+        image: mesosphere/kubeaddons-addon-initializer:v0.2.3
+        args: ["dex"]
+        env:
+        - name: "DEX_NAMESPACE"
+          value: "kubeaddons"
+        - name: "DEX_SECRET_NAME"
+          value: "dex-kubeaddons"
+        - name: "OPS_PORTAL_NAMESPACE"
+          value: "kubeaddons"
+        - name: "OPS_PORTAL_SECRET_NAME"
+          value: "ops-portal-credentials"
+        - name: "TRAEFIK_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TRAEFIK_SERVICE_NAME"
+          value: "traefik-kubeaddons"


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
* adds hmac_secret default value
* bumps dka image
* bumps dka initContainer image
* adds additional redirect URL to dex config

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-65269

**Special notes for your reviewer**:
changes commits: https://github.com/mesosphere/kubernetes-base-addons/pull/193/commits/dc48b05eea61081481110f542aef57f05cd938ec, https://github.com/mesosphere/kubernetes-base-addons/pull/193/commits/1583e71512aa2a926c87b78a3c51fe7f2c787d9f

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
