### PR TITLE
cert-manager: chart bump cert-manager-setup

### DIFF
--- a/addons/cert-manager/0.10.x/cert-manager-4.yaml
+++ b/addons/cert-manager/0.10.x/cert-manager-4.yaml
@@ -6,10 +6,10 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: cert-manager
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.10.1-3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.10.1-4"
     appversion.kubeaddons.mesosphere.io/cert-manager: "0.10.1"
     docs.kubeaddons.mesosphere.io/cert-manager: "https://docs.cert-manager.io/en/release-0.10/"
-    values.chart.helm.kubeaddons.mesosphere.io/cert-manager: "https://raw.githubusercontent.com/mesosphere/charts/68ababd/staging/cert-manager-setup/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/cert-manager: "https://raw.githubusercontent.com/mesosphere/charts/c12fac8/staging/cert-manager-setup/values.yaml"
 spec:
   namespace: cert-manager
   kubernetes:
@@ -28,7 +28,7 @@ spec:
   chartReference:
     chart: cert-manager-setup
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.1.9
+    version: 0.1.10
     values: |
       ---
       issuers:
@@ -41,10 +41,10 @@ spec:
           issuerRef:
             name: kubernetes-root-issuer
             kind: Issuer
-            # These are the default usages for reference
-            usages:
-              - "digital signature"
-              - "key encipherment"
+          # These are the default usages for reference
+          usages:
+            - "digital signature"
+            - "key encipherment"
           commonName: cert-manager
           duration: 87600h
           dnsNames: []

--- a/addons/cert-manager/0.10.x/cert-manager-4.yaml
+++ b/addons/cert-manager/0.10.x/cert-manager-4.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: cert-manager
+  labels:
+    kubeaddons.mesosphere.io/name: cert-manager
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.10.1-3"
+    appversion.kubeaddons.mesosphere.io/cert-manager: "0.10.1"
+    docs.kubeaddons.mesosphere.io/cert-manager: "https://docs.cert-manager.io/en/release-0.10/"
+    values.chart.helm.kubeaddons.mesosphere.io/cert-manager: "https://raw.githubusercontent.com/mesosphere/charts/68ababd/staging/cert-manager-setup/values.yaml"
+spec:
+  namespace: cert-manager
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  chartReference:
+    chart: cert-manager-setup
+    repo: https://mesosphere.github.io/charts/staging
+    version: 0.1.9
+    values: |
+      ---
+      issuers:
+        - name: kubernetes-root-issuer
+          secretName: kubernetes-root-ca
+
+      certificates:
+        - name: kubernetes-intermediate-ca
+          secretName: kubernetes-intermediate-ca
+          issuerRef:
+            name: kubernetes-root-issuer
+            kind: Issuer
+            # These are the default usages for reference
+            usages:
+              - "digital signature"
+              - "key encipherment"
+          commonName: cert-manager
+          duration: 87600h
+          dnsNames: []
+
+      clusterissuers:
+        - name: kubernetes-ca
+          spec:
+            ca:
+              secretName: kubernetes-intermediate-ca


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
- `usages` is not part of an Issuer / IssuerRef, it belongs to the Certificate

see https://docs.cert-manager.io/en/release-0.10/reference/api-docs/index.html#certificate-v1alpha1

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

[D2IQ-65995]

[D2IQ-65995]: https://jira.d2iq.com/browse/D2IQ-65995

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`usages` is no longer definable as part of `issuerRef`, instead it is a key on its own
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.