### PR TITLE
Add monitoring tests

### DIFF
--- a/test/addons_test.go
+++ b/test/addons_test.go
@@ -112,7 +112,7 @@ func TestElasticsearchGroup(t *testing.T) {
 }
 
 func TestPrometheusGroup(t *testing.T) {
-	if err := testgroup(t, "prometheus"); err != nil {
+	if err := testgroup(t, "prometheus", promChecker, alertmanagerChecker, grafanaChecker); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/test/addons_test.go
+++ b/test/addons_test.go
@@ -411,4 +411,14 @@ data:
       cpu: 100m
       memory: 1024Mi
 `,
+	"prometheus": `
+---
+# Remove dependency on persistent volumes and Konvoy's "etcd-certs" secret.
+prometheus:
+  prometheusSpec:
+    secrets: []
+    storageSpec: null
+kubeEtcd:
+  enabled: false
+`,
 }

--- a/test/prometheus_test.go
+++ b/test/prometheus_test.go
@@ -9,8 +9,6 @@ import (
 
 	testcluster "github.com/mesosphere/ksphere-testing-framework/pkg/cluster"
 	testharness "github.com/mesosphere/ksphere-testing-framework/pkg/harness"
-	networkutils "github.com/mesosphere/ksphere-testing-framework/pkg/utils/networking"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -26,19 +24,9 @@ const (
 
 func promChecker(t *testing.T, cluster testcluster.Cluster) testharness.Job {
 	return func(t *testing.T) error {
-		pod, err := findPodWithPrefix(cluster, "kubeaddons", promPodPrefix)
+		localport, stop, err := portForwardPodWithPrefix(cluster, "kubeaddons", promPodPrefix, promPort)
 		if err != nil {
-			return fmt.Errorf("could not find prometheus pod: %s", err)
-		}
-		if pod.Status.Phase != corev1.PodRunning {
-			return fmt.Errorf("prometheus pod %s is not running, it's in phase %s", pod.Name, pod.Status.Phase)
-		}
-		t.Logf("INFO: checking prometheus at pod/%s port %s", pod.Name, promPort)
-
-		// Forward a local port to the prometheus API.
-		localport, stop, err := networkutils.PortForward(cluster.Config(), pod.Namespace, pod.Name, promPort)
-		if err != nil {
-			return fmt.Errorf("could not set up port forward for pod/%s port %s: %s", pod.Name, promPort, err)
+			return fmt.Errorf("could not forward port to prometheus pod: %s", err)
 		}
 		defer close(stop)
 
@@ -75,19 +63,9 @@ func promChecker(t *testing.T, cluster testcluster.Cluster) testharness.Job {
 
 func alertmanagerChecker(t *testing.T, cluster testcluster.Cluster) testharness.Job {
 	return func(t *testing.T) error {
-		pod, err := findPodWithPrefix(cluster, "kubeaddons", alertmanagerPodPrefix)
+		localport, stop, err := portForwardPodWithPrefix(cluster, "kubeaddons", alertmanagerPodPrefix, alertmanagerPort)
 		if err != nil {
-			return fmt.Errorf("could not find alertmanager pod: %s", err)
-		}
-		if pod.Status.Phase != corev1.PodRunning {
-			return fmt.Errorf("alertmanager pod %s is not running, it's in phase %s", pod.Name, pod.Status.Phase)
-		}
-		t.Logf("INFO: checking alertmanager at pod/%s port %s", pod.Name, alertmanagerPort)
-
-		// Forward a local port to the alertmanager API.
-		localport, stop, err := networkutils.PortForward(cluster.Config(), pod.Namespace, pod.Name, alertmanagerPort)
-		if err != nil {
-			return fmt.Errorf("could not set up port forward for pod/%s port %s: %s", pod.Name, alertmanagerPort, err)
+			return fmt.Errorf("could not forward port to alertmanager pod: %s", err)
 		}
 		defer close(stop)
 
@@ -128,19 +106,9 @@ func alertmanagerChecker(t *testing.T, cluster testcluster.Cluster) testharness.
 
 func grafanaChecker(t *testing.T, cluster testcluster.Cluster) testharness.Job {
 	return func(t *testing.T) error {
-		pod, err := findPodWithPrefix(cluster, "kubeaddons", grafanaPodPrefix)
+		localport, stop, err := portForwardPodWithPrefix(cluster, "kubeaddons", grafanaPodPrefix, grafanaPort)
 		if err != nil {
-			return fmt.Errorf("could not find grafana pod: %s", err)
-		}
-		if pod.Status.Phase != corev1.PodRunning {
-			return fmt.Errorf("grafana pod %s is not running, it's in phase %s", pod.Name, pod.Status.Phase)
-		}
-		t.Logf("INFO: checking grafana at pod/%s port %s", pod.Name, grafanaPort)
-
-		// Forward a local port to the grafana API.
-		localport, stop, err := networkutils.PortForward(cluster.Config(), pod.Namespace, pod.Name, grafanaPort)
-		if err != nil {
-			return fmt.Errorf("could not set up port forward for pod/%s port %s: %s", pod.Name, grafanaPort, err)
+			return fmt.Errorf("could not forward port to grafana pod: %s", err)
 		}
 		defer close(stop)
 

--- a/test/prometheus_test.go
+++ b/test/prometheus_test.go
@@ -1,0 +1,181 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	testcluster "github.com/mesosphere/ksphere-testing-framework/pkg/cluster"
+	testharness "github.com/mesosphere/ksphere-testing-framework/pkg/harness"
+	networkutils "github.com/mesosphere/ksphere-testing-framework/pkg/utils/networking"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	promPodPrefix = "prometheus-prometheus-kubeaddons-prom-prometheus-"
+	promPort      = "9090"
+
+	alertmanagerPodPrefix = "alertmanager-prometheus-kubeaddons-prom-alertmanager-"
+	alertmanagerPort      = "9093"
+
+	grafanaPodPrefix = "prometheus-kubeaddons-grafana"
+	grafanaPort      = "3000"
+)
+
+func promChecker(t *testing.T, cluster testcluster.Cluster) testharness.Job {
+	return func(t *testing.T) error {
+		pod, err := findPodWithPrefix(cluster, "kubeaddons", promPodPrefix)
+		if err != nil {
+			return fmt.Errorf("could not find prometheus pod: %s", err)
+		}
+		if pod.Status.Phase != corev1.PodRunning {
+			return fmt.Errorf("prometheus pod %s is not running, it's in phase %s", pod.Name, pod.Status.Phase)
+		}
+		t.Logf("INFO: checking prometheus at pod/%s port %s", pod.Name, promPort)
+
+		// Forward a local port to the prometheus API.
+		localport, stop, err := networkutils.PortForward(cluster.Config(), pod.Namespace, pod.Name, promPort)
+		if err != nil {
+			return fmt.Errorf("could not set up port forward for pod/%s port %s: %s", pod.Name, promPort, err)
+		}
+		defer close(stop)
+
+		// Query prometheus and assert the response status is success.
+		var resp *http.Response
+		path := "/api/v1/labels"
+		resp, err = http.Get(fmt.Sprintf("http://localhost:%d%s", localport, path))
+		if err != nil {
+			return fmt.Errorf("could not GET %s: %s", path, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("expected GET %s status %d, got %d", path, http.StatusOK, resp.StatusCode)
+		}
+
+		b, err := ioutil.ReadAll(resp.Body)
+		obj := map[string]interface{}{}
+		if err := json.Unmarshal(b, &obj); err != nil {
+			return fmt.Errorf("could not decode JSON response: %s", err)
+		}
+
+		status, ok := obj["status"].(string)
+		if !ok {
+			return fmt.Errorf("JSON response missing key status with string value")
+		}
+		if status != "success" {
+			return fmt.Errorf("expected status success, got %s", status)
+		}
+
+		t.Logf("INFO: successfully tested prometheus")
+		return nil
+	}
+}
+
+func alertmanagerChecker(t *testing.T, cluster testcluster.Cluster) testharness.Job {
+	return func(t *testing.T) error {
+		pod, err := findPodWithPrefix(cluster, "kubeaddons", alertmanagerPodPrefix)
+		if err != nil {
+			return fmt.Errorf("could not find alertmanager pod: %s", err)
+		}
+		if pod.Status.Phase != corev1.PodRunning {
+			return fmt.Errorf("alertmanager pod %s is not running, it's in phase %s", pod.Name, pod.Status.Phase)
+		}
+		t.Logf("INFO: checking alertmanager at pod/%s port %s", pod.Name, alertmanagerPort)
+
+		// Forward a local port to the alertmanager API.
+		localport, stop, err := networkutils.PortForward(cluster.Config(), pod.Namespace, pod.Name, alertmanagerPort)
+		if err != nil {
+			return fmt.Errorf("could not set up port forward for pod/%s port %s: %s", pod.Name, alertmanagerPort, err)
+		}
+		defer close(stop)
+
+		// Check alertmanager status is ready.
+		var resp *http.Response
+		path := "/api/v2/status"
+		resp, err = http.Get(fmt.Sprintf("http://localhost:%d%s", localport, path))
+		if err != nil {
+			return fmt.Errorf("could not GET %s: %s", path, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("expected GET %s status %d, got %d", path, http.StatusOK, resp.StatusCode)
+		}
+
+		b, err := ioutil.ReadAll(resp.Body)
+		obj := map[string]interface{}{}
+		if err := json.Unmarshal(b, &obj); err != nil {
+			return fmt.Errorf("could not decode JSON response: %s", err)
+		}
+
+		clusterObj, ok := obj["cluster"].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("JSON response missing key cluster with object value")
+		}
+		status, ok := clusterObj["status"].(string)
+		if !ok {
+			return fmt.Errorf("cluster missing key status with string value")
+		}
+		if status != "ready" {
+			return fmt.Errorf("expected status ready, got %s", status)
+		}
+
+		t.Logf("INFO: successfully tested alertmanager")
+		return nil
+	}
+}
+
+func grafanaChecker(t *testing.T, cluster testcluster.Cluster) testharness.Job {
+	return func(t *testing.T) error {
+		pod, err := findPodWithPrefix(cluster, "kubeaddons", grafanaPodPrefix)
+		if err != nil {
+			return fmt.Errorf("could not find grafana pod: %s", err)
+		}
+		if pod.Status.Phase != corev1.PodRunning {
+			return fmt.Errorf("grafana pod %s is not running, it's in phase %s", pod.Name, pod.Status.Phase)
+		}
+		t.Logf("INFO: checking grafana at pod/%s port %s", pod.Name, grafanaPort)
+
+		// Forward a local port to the grafana API.
+		localport, stop, err := networkutils.PortForward(cluster.Config(), pod.Namespace, pod.Name, grafanaPort)
+		if err != nil {
+			return fmt.Errorf("could not set up port forward for pod/%s port %s: %s", pod.Name, grafanaPort, err)
+		}
+		defer close(stop)
+
+		// Check grafana is healthy.
+		var resp *http.Response
+		path := "/api/health"
+		req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d%s", localport, path), nil)
+		if err != nil {
+			return fmt.Errorf("could not create GET %s: %s", path, err)
+		}
+		req.Header.Set("X-Forwarded-User", "admin")
+		resp, err = (&http.Client{}).Do(req)
+		if err != nil {
+			return fmt.Errorf("could not GET %s: %s", path, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("expected GET %s status %d, got %d", path, http.StatusOK, resp.StatusCode)
+		}
+
+		b, err := ioutil.ReadAll(resp.Body)
+		obj := map[string]interface{}{}
+		if err := json.Unmarshal(b, &obj); err != nil {
+			return fmt.Errorf("could not decode JSON response: %s", err)
+		}
+
+		status, ok := obj["database"].(string)
+		if !ok {
+			return fmt.Errorf("JSON response missing key database with string value")
+		}
+		if status != "ok" {
+			return fmt.Errorf("expected status ok, got %s", status)
+		}
+
+		t.Logf("INFO: successfully tested grafana")
+		return nil
+	}
+}

--- a/test/util.go
+++ b/test/util.go
@@ -1,0 +1,40 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+
+	testcluster "github.com/mesosphere/ksphere-testing-framework/pkg/cluster"
+	networkutils "github.com/mesosphere/ksphere-testing-framework/pkg/utils/networking"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func portForwardPodWithPrefix(cluster testcluster.Cluster, ns, prefix, port string) (int, chan struct{}, error) {
+	pod, err := findPodWithPrefix(cluster, ns, prefix)
+	if err != nil {
+		return 0, nil, fmt.Errorf("could not find pod with prefix %s: %s", prefix, err)
+	}
+	if pod.Status.Phase != corev1.PodRunning {
+		return 0, nil, fmt.Errorf("pod %s is not running, it's in phase %s", pod.Name, pod.Status.Phase)
+	}
+	return networkutils.PortForward(cluster.Config(), pod.Namespace, pod.Name, port)
+}
+
+func findPodWithPrefix(cluster testcluster.Cluster, ns, prefix string) (*corev1.Pod, error) {
+	pods, err := cluster.Client().CoreV1().Pods(ns).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pod := range pods.Items {
+		if pod.ObjectMeta.GetDeletionTimestamp() != nil {
+			continue
+		}
+		if strings.HasPrefix(pod.Name, prefix) {
+			return &pod, nil
+		}
+	}
+
+	return nil, fmt.Errorf("pod with name prefix %s in namespace %s not found", prefix, ns)
+}


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This updates the test for the Prometheus addon group to verify that Prometheus, Alertmanager, and Grafana serve requests after they are deployed.

This PR also overrides Prometheus addon configuration for tests so that it can deploy on a kind cluster. It removes references to the `etcd-certs` secret that's only present on Konvoy clusters. It also removes a dependence on persistent volumes.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-65335

**Special notes for your reviewer**:

This PR depends on some code added by #208.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [x] The documentation is updated where needed.
