### PR TITLE
velero: bump charts, use json logging

### DIFF
--- a/addons/velero/1.0.x/velero-6.yaml
+++ b/addons/velero/1.0.x/velero-6.yaml
@@ -1,0 +1,120 @@
+---
+# ------------------------------------------------------------------------------
+# Velero
+#
+#
+# Velero is an open source backup and migration tool for Kubernetes.
+# See more about Velero at:
+#
+# * https://velero.io/
+# * https://github.com/heptio/velero
+# * https://github.com/helm/charts/tree/master/stable/velero
+#
+#
+# Implementation
+#
+#
+# Our implementation of Velero currently supports S3 backends for storage, and by default if no configuration overrides are
+# provided to point it at a backend other than the default, we will create and manage a distributed Minio (https://min.io/)
+# cluster which uses the default storage class for the cluster to maintain the backups.
+#
+#
+# WARNING: using the default (fallback) backend is for testing purposes only and should not be used in production.
+# ------------------------------------------------------------------------------
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: velero
+  labels:
+    kubeaddons.mesosphere.io/name: velero
+    # TODO: we're temporarily supporting dependency on an existing default storage class
+    # on the cluster, this hack will trigger re-queue on Addons until one exists.
+    kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.1-5"
+    values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/mesosphere/charts/5327e6a54fe70df550e894fd754541a4f71a9054/staging/velero/values.yaml"
+spec:
+  namespace: velero
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: none
+      enabled: true
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/provides: ingresscontroller
+  chartReference:
+    chart: velero
+    repo: https://mesosphere.github.io/charts/staging
+    version: 3.0.4
+    values: |
+      ---
+      configuration:
+        provider: "aws"
+        backupStorageLocation:
+          name: "aws"
+          bucket: "velero"
+          config:
+            region: "fallback"     # enables non-production fallback minio backend
+            s3ForcePathStyle: true # allows usage of fallback backend
+            s3Url: http://minio.velero.svc:9000
+        volumeSnapshotLocation:
+          name: "aws"
+          config:
+            region: "fallback"
+      credentials:
+        secretContents:
+          cloud: "placeholder"
+      schedules:
+        default:
+          schedule: "0 0 * * *"
+      metrics:
+        enabled: true
+        service:
+          labels:
+            servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
+      initContainers:
+      - name: initialize-velero
+        image: mesosphere/kubeaddons-addon-initializer:v0.2.5
+        args: ["velero"]
+        env:
+        - name: "VELERO_MINIO_FALLBACK_SECRET_NAME"
+          value: "velero-kubeaddons"
+      minioBackend: true
+      minio:
+        mode: distributed
+        extraArgs:
+          - --json
+        defaultBucket:
+          enabled: true
+          name: velero
+        bucketRoot: "/data"
+        mountPath: "/data"
+        existingSecret: minio-creds-secret
+        livenessProbe:
+          initialDelaySeconds: 120
+          periodSeconds: 20
+        resources:
+          requests:
+            memory: 256Mi
+            cpu: 250m
+          limits:
+            memory: 512Mi
+            cpu: 750m
+        persistence:
+          volumeTemplatePrefix: data
+        statefulSetNameOverride: minio
+        statefulSetForceCleanup: true
+        ingress:
+          enabled: true
+          hosts:
+          - ""
+          annotations:
+            kubernetes.io/ingress.class: traefik
+            traefik.ingress.kubernetes.io/frontend-entry-points: velero-minio


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What this PR does/ why we need it**:
Currently, the minio backend logs do not contain timestamp, and this makes minio backend failures hard to debug and log corelation impossible. This change fixes that by switching from plaintext logging to json logging by appending the `--json` flag to the `server` subcommand call. Example logs:
```
# vespian @ budrys in ~kv/out-linux on git:416cefc5 o [16:09:44]
$ k logs -n velero minio-1
{"level":"INFO","errKind":"","time":"2020-04-14T13:58:28.97670303Z","message":"Waiting for the first server to format the disks.\n"}
{"level":"INFO","errKind":"","time":"2020-04-14T13:58:29.476333006Z","message":"Waiting for the first server to format the disks.\n"}

# vespian @ budrys in ~kv/out-linux on git:416cefc5 o [16:09:50]
$ k logs -n velero minio-0
{"level":"INFO","errKind":"","time":"2020-04-14T13:58:29.818147482Z","message":"Formatting 1 zone, 1 set(s), 4 drives per set.\n"}
{"level":"INFO","errKind":"","time":"2020-04-14T13:58:29.833127358Z","message":"Attempting encryption of all config, IAM users and policies on MinIO backend\n"}

# vespian @ budrys in ~kv/out-linux on git:416cefc5 o [16:09:58]
$ k logs -n velero minio-2
{"level":"INFO","errKind":"","time":"2020-04-14T13:58:29.145658314Z","message":"Waiting for the first server to format the disks.\n"}
{"level":"INFO","errKind":"","time":"2020-04-14T13:58:29.645272662Z","message":"Waiting for the first server to format the disks.\n"}
```

We are also bumping the charts via https://github.com/mesosphere/charts/pull/547 as so far the `extraArgs` chart parameter did not work - please check the PR description for more details.

Change can be summarized as:
```
# vespian @ budrys in ~/work/git_repos/kubernetes-base-addons/addons/velero/1.0.x on git:prozlach/D2IQ-66612_minio_json_logging o [16:20:02]
$ diff -Nwrup ./velero-{5,6}.yaml
--- ./velero-5.yaml     2020-04-14 13:24:11.511955494 +0200
+++ ./velero-6.yaml     2020-04-14 16:19:36.531727645 +0200
@@ -52,7 +52,7 @@ spec:
   chartReference:
     chart: velero
     repo: https://mesosphere.github.io/charts/staging
-    version: 3.0.3
+    version: 3.0.4
     values: |
       ---
       configuration:
@@ -89,6 +89,8 @@ spec:
       minioBackend: true
       minio:
         mode: distributed
+        extraArgs:
+          - --json
         defaultBucket:
           enabled: true

```

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-66612

**Special notes for your reviewer**:
https://github.com/mesosphere/charts/pull/547 should be merged first.

**Does this PR introduce a user-facing change?**:

```release-note
switch minio backend logging from plaintext to json
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
