### PR TITLE
traefik: update initContainer

### DIFF
--- a/addons/traefik/1.7.x/traefik-9.yaml
+++ b/addons/traefik/1.7.x/traefik-9.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: traefik
+  labels:
+    kubeaddons.mesosphere.io/name: traefik
+    kubeaddons.mesosphere.io/provides: ingresscontroller
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.7.23-9"
+    appversion.kubeaddons.mesosphere.io/traefik: "1.7.23"
+    endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
+    docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/v1.7"
+    values.chart.helm.kubeaddons.mesosphere.io/traefik: "https://raw.githubusercontent.com/mesosphere/charts/984fef43d4e65aa4c48753d2dbf2420789c7d1a7/staging/traefik/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: cert-manager
+  chartReference:
+    chart: traefik
+    repo: https://mesosphere.github.io/charts/staging
+    version: 1.72.18
+    values: |
+      ---
+      replicas: 2
+      service:
+        labels:
+          servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
+      resources:
+        limits:
+          cpu: 1000m
+        requests:
+          cpu: 500m
+      rbac:
+        enabled: true
+      metrics:
+        prometheus:
+          enabled: true
+      dashboard:
+        enabled: true
+        domain: ""
+        serviceType: ClusterIP
+        ingress:
+          path: /ops/portal/traefik
+          annotations:
+            kubernetes.io/ingress.class: traefik
+            traefik.frontend.rule.type: PathPrefixStrip
+            traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User,Authorization,Impersonate-User,Impersonate-Group
+            traefik.ingress.kubernetes.io/auth-type: forward
+            traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
+            traefik.ingress.kubernetes.io/priority: "2"
+      kubernetes:
+        ingressEndpoint:
+          publishedService: "kubeaddons/traefik-kubeaddons"
+      ssl:
+        enabled: true
+        enforced: true
+        # TODO: This comment is no longer true.
+        # dex service is exposed with TLS certificate signed by self signed root
+        # Dex CA certificate. It is not clear if traefik supports configuring
+        # trusted certificates per backend. This should be investiaged in a
+        # separate issue.
+        # See: https://jira.mesosphere.com/browse/DCOS-56033
+        insecureSkipVerify: true
+        # We use cert-manager to automate certificate management thus we
+        # do not need the default cert secret.
+        useCertManager: true
+      deploymentAnnotations:
+        # Watching this CM will trigger traefik init container that updates certificate
+        # object with new DNS names. That will cascade secret update which will trigger
+        # another reload.
+        configmap.reloader.stakater.com/reload: konvoyconfig-kubeaddons
+        secret.reloader.stakater.com/reload: traefik-kubeaddons-certificate
+
+      initContainers:
+      - name: initialize-traefik-certificate
+        image: mesosphere/kubeaddons-addon-initializer:v0.2.9
+        args: ["traefik"]
+        env:
+        - name: "TRAEFIK_INGRESS_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TRAEFIK_INGRESS_SERVICE_NAME"
+          value: "traefik-kubeaddons"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_NAME"
+          value: "traefik-kubeaddons"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_ISSUER"
+          value: "kubernetes-ca"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_SECRET_NAME"
+          value: "traefik-kubeaddons-certificate"
+        - name: "TRAEFIK_KONVOY_ADDONS_CONFIG_MAP"
+          value: "konvoyconfig-kubeaddons"
+        - name: "TRAEFIK_CLUSTER_HOSTNAME_KEY"
+          value: "clusterHostname"
+
+      initCertJobImage: mesosphere/kubeaddons-addon-initializer:v0.2.9
+      extraServicePorts:
+        - name: velero-minio
+          port: 9000
+          protocol: TCP
+          targetPort: 9000
+      extraConfigEntrypoints: |
+        [entryPoints.velero-minio]
+        address = ":9000"
+          [entryPoints.velero-minio.tls]
+          [entryPoints.velero-minio.tls.defaultCertificate]
+          certFile = "/ssl/tls.crt"
+          keyFile = "/ssl/tls.key"


### PR DESCRIPTION
**What type of PR is this?**
Chore

**What this PR does/ why we need it**:
Bump the ClusterAddon to use `kubeaddons-addon-initializer:v0.2.9` which results in Traefik printing a bit more logs.
Also bump the `values.chart.helm.kubeaddons.mesosphere.io/traefik` to the latest version available in mesosphere/charts.

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-66751

**Special notes for your reviewer**:
Tested manually by spinning up a Konvoy cluster and replacing the Traefik ClusterAddon.
In comparison, here is the previous addon definition: https://github.com/mesosphere/kubernetes-base-addons/blob/1bd6d5eeec0f98bc4a460ae01dc882d3e0d38a27/addons/traefik/1.7.x/traefik-8.yaml 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [X] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
