### PR TITLE
tfa: added traefik.ingress.kubernetes.io/auth-response-headers

### DIFF
--- a/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-5.yaml
+++ b/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-5.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: traefik-forward-auth
+  namespace: kubeaddons
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.4-4"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: dex
+    - matchLabels:
+        kubeaddons.mesosphere.io/provides: ingresscontroller
+  chartReference:
+    chart: traefik-forward-auth
+    repo: https://mesosphere.github.io/charts/staging
+    version: 0.2.13
+    values: |
+      ---
+      replicaCount: 1
+      image:
+        repository: mesosphere/traefik-forward-auth
+        tag: 2.0.3
+        pullPolicy: IfNotPresent
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      service:
+        type: ClusterIP
+        port: 4181
+      traefikForwardAuth:
+        # oidcUri will be overridden by the init-container
+        oidcUri: "https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex"
+        clientId: traefik-forward-auth
+        clientSecret:
+          valueFrom:
+            secretKeyRef:
+              name: dex-client-secret-traefik-forward-auth
+              key: client_secret
+        cookieSecure: true
+        userCookieName: "konvoy_profile_name"
+        extraConfig:
+          auth-host = dex-kubeaddons.kubeaddons.svc.cluster.local:8080
+        enableRBAC: true
+        enableImpersonation: true
+        rbacPassThroughPaths: ["/ops/portal/kubernetes/", "/ops/portal/kubernetes/*"]
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.class: traefik
+          ingress.kubernetes.io/protocol: https
+          traefik.ingress.kubernetes.io/auth-type: forward
+          traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
+          traefik.ingress.kubernetes.io/priority: "1"
+        paths:
+          - /_oauth
+        hosts:
+          - ""
+        tls: []
+      deploymentAnnotations:
+        # The certificate can change because it was rotated or different cluster
+        # DNS name has been set.
+        secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate,dex-kubeaddons"
+      initContainers:
+      # initialize-traefik-forward-auth deploys credentials for use by the proxy
+      - name: initialize-traefik-forward-auth
+        image: mesosphere/kubeaddons-addon-initializer:v0.1.8
+        args: ["traefikforwardauth"]
+        env:
+        - name: "TFA_CONFIGMAP_NAME"
+          value: "traefik-forward-auth-kubeaddons-configmap"
+        - name: "TFA_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TFA_INGRESS_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TFA_INGRESS_SERVICE_NAME"
+          value: "traefik-kubeaddons"

--- a/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-5.yaml
+++ b/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-5.yaml
@@ -5,7 +5,7 @@ metadata:
   name: traefik-forward-auth
   namespace: kubeaddons
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.4-4"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.4-5"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -34,7 +34,7 @@ spec:
       replicaCount: 1
       image:
         repository: mesosphere/traefik-forward-auth
-        tag: 2.0.3
+        tag: 2.0.4
         pullPolicy: IfNotPresent
       resources:
         requests:
@@ -64,6 +64,7 @@ spec:
         annotations:
           kubernetes.io/ingress.class: traefik
           ingress.kubernetes.io/protocol: https
+          traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User,Impersonate-User,Impersonate-Group
           traefik.ingress.kubernetes.io/auth-type: forward
           traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
           traefik.ingress.kubernetes.io/priority: "1"
@@ -79,7 +80,7 @@ spec:
       initContainers:
       # initialize-traefik-forward-auth deploys credentials for use by the proxy
       - name: initialize-traefik-forward-auth
-        image: mesosphere/kubeaddons-addon-initializer:v0.1.8
+        image: mesosphere/kubeaddons-addon-initializer:v0.2.9
         args: ["traefikforwardauth"]
         env:
         - name: "TFA_CONFIGMAP_NAME"


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

enables auth-respones-headers

- bumped tfa version
- bumped mesosphere/kubeaddons-addon-initializer version

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

[D2IQ-67264]

[D2IQ-67264]: https://jira.d2iq.com/browse/D2IQ-67264

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.