### PR TITLE
chore: bump awsebscsiprovisioner

### DIFF
--- a/addons/awsebscsiprovisioner/0.5.x/awsebscsiprovisioner-3.yaml
+++ b/addons/awsebscsiprovisioner/0.5.x/awsebscsiprovisioner-3.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: awsebscsiprovisioner
+  labels:
+    kubeaddons.mesosphere.io/name: awsebscsiprovisioner
+    kubeaddons.mesosphere.io/provides: storageclass
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.5.0-2"
+    appversion.kubeaddons.mesosphere.io/awsebscsiprovisioner: "0.5.0"
+    values.chart.helm.kubeaddons.mesosphere.io/awsebscsiprovisioner: "https://raw.githubusercontent.com/mesosphere/charts/b6e53ee/stable/awsebscsiprovisioner/values.yaml"
+spec:
+  namespace: kube-system
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: defaultstorageclass-protection
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+  chartReference:
+    version: 0.3.6
+    chart: awsebscsiprovisioner
+    repo: https://mesosphere.github.io/charts/stable
+    values: |
+      ---
+      resizer:
+        enabled: false
+      snapshotter:
+        enabled: true
+      provisioner:
+        enableVolumeScheduling: true
+      storageclass:
+        isDefault: true
+        reclaimPolicy: Delete
+        volumeBindingMode: WaitForFirstConsumer
+        type: gp2
+        fstype: ext4
+        iopsPerGB: null
+        encrypted: false
+        kmsKeyId: null
+        allowedTopologies: []
+        # - matchLabelExpressions:
+        #   - key: topology.ebs.csi.aws.com/zone
+        #     values:
+        #     - us-west-2a
+        #     - us-west-2b
+        #     - us-west-2c
+        allowVolumeExpansion: true
+      # replicas of the CSI-Controller
+      replicas: 1
+      statefulSetCSIController:
+      # if you want to use kube2iam or kiam roles define it here as podAnnotation for the CSI-Controller (statefulSet)
+        podAnnotations: {}
+      statefulSetCSISnapshotController:
+        # if you want to use kube2iam or kiam roles define it here as podAnnotation for the CSI-Snapshot-Controller (statefulSet)
+        podAnnotations: {}
+      # Extra volume tags to attach to each dynamically provisioned volume.
+      # ---
+      # extraVolumeTags:
+      #   key1: value1
+      #   key2: value2
+      extraVolumeTags: {}

--- a/addons/awsebscsiprovisioner/0.5.x/awsebscsiprovisioner-3.yaml
+++ b/addons/awsebscsiprovisioner/0.5.x/awsebscsiprovisioner-3.yaml
@@ -7,9 +7,9 @@ metadata:
     kubeaddons.mesosphere.io/name: awsebscsiprovisioner
     kubeaddons.mesosphere.io/provides: storageclass
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.5.0-2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.5.0-3"
     appversion.kubeaddons.mesosphere.io/awsebscsiprovisioner: "0.5.0"
-    values.chart.helm.kubeaddons.mesosphere.io/awsebscsiprovisioner: "https://raw.githubusercontent.com/mesosphere/charts/b6e53ee/stable/awsebscsiprovisioner/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/awsebscsiprovisioner: "https://raw.githubusercontent.com/mesosphere/charts/268df59/stable/awsebscsiprovisioner/values.yaml"
 spec:
   namespace: kube-system
   requires:
@@ -21,13 +21,13 @@ spec:
     - name: aws
       enabled: true
   chartReference:
-    version: 0.3.6
+    version: 0.3.7
     chart: awsebscsiprovisioner
     repo: https://mesosphere.github.io/charts/stable
     values: |
       ---
       resizer:
-        enabled: false
+        enabled: true
       snapshotter:
         enabled: true
       provisioner:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
- bump awsebscsiprovisioner
- also enable resizer per default

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
[D2IQ-68177]

[D2IQ-68177]: https://jira.d2iq.com/browse/D2IQ-68177
**Special notes for your reviewer**:
chart changes here https://github.com/mesosphere/charts/pull/580

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Kubernetes upgrade to 1.17.x

The change from v1alpha1 to v1beta1 snapshot APIs is not backward compatible.
If you already have a Konvoy Cluster with Kubernetes version < 1.17 you would need
follow these instructions before upgrading the Konvoy Cluster to kubernetes 1.17:

**Note: The underlying snapshots on the storage system will be deleted in the upgrade process!!!**

1. Delete volume snapshots created using v1alpha1 snapshot CRDs and external-snapshotter sidecar controller.

2. Set the replicas to 0 for the statefulSet `ebs-csi-controller`

- `kubectl scale statefulset -n kube-system ebs-csi-controller --replicas=0`

3. Uninstall v1alpha1 snapshot CRDs

- `kubectl delete customresourcedefinitions.apiextensions.k8s.io volumesnapshotclasses.snapshot.storage.k8s.io`
- `kubectl delete customresourcedefinitions.apiextensions.k8s.io volumesnapshotcontents.snapshot.storage.k8s.io`
- `kubectl delete customresourcedefinitions.apiextensions.k8s.io volumesnapshots.snapshot.storage.k8s.io`

4. Rollout upgrade to Kubernetes 1.17

5. Set the replicas back to what it was before (e.g. 2) for the statefulSet `ebs-csi-controller`

- `kubectl scale statefulset -n kube-system ebs-csi-controller --replicas=2`
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [x] The documentation is updated where needed.