### PR TITLE
Clarify supported k8s versions in release docs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,11 +20,9 @@ Releases should be twice monthly<sup>[1](#footnote1)</sup> on the second and for
 
 ### Kubernetes
 
-The Addons in this repo are the minimum base set of supported<sup>[2](#footnote2)</sup> Addons to be installed as a suite for any supported version of Kubernetes.
+**The Kubernetes versions supported by this repo are 1.15, 1.16, and 1.17.**
 
-Kubernetes support must be maintained for the latest general release of Kubernetes and the two prior minor releases.
-At the time of this writing, the latest Kubernetes release is 1.17.2.
-Support from this repo, at this time, should cover 1.15.x, 1.16.x, and 1.17.x.
+The Addons in this repo are the minimum base set of supported<sup>[2](#footnote2)</sup> Addons to be installed as a suite for any supported version of Kubernetes.
 
 ### Branches and Tags
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,6 +21,7 @@ Releases should be twice monthly<sup>[1](#footnote1)</sup> on the second and for
 ### Kubernetes
 
 **The Kubernetes versions supported by this repo are 1.15, 1.16, and 1.17.**
+Support should be maintained for the latest general release of Kubernetes and the two prior minor releases.
 
 The Addons in this repo are the minimum base set of supported<sup>[2](#footnote2)</sup> Addons to be installed as a suite for any supported version of Kubernetes.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Documentation

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This tweaks release docs to make the supported Kubernetes versions a little more clear. It also removes a declaration about supporting the latest GA release, since 1.18 has been out for a few weeks and we don't plan to add support in the immediate future.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
No issue.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [x] The documentation is updated where needed.
