### PR TITLE
 traefik: bump to chart 1.72.19

### DIFF
--- a/addons/traefik/1.7.x/traefik-10.yaml
+++ b/addons/traefik/1.7.x/traefik-10.yaml
@@ -7,11 +7,11 @@ metadata:
     kubeaddons.mesosphere.io/name: traefik
     kubeaddons.mesosphere.io/provides: ingresscontroller
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.7.23-9"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.7.23-10"
     appversion.kubeaddons.mesosphere.io/traefik: "1.7.23"
     endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
     docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/v1.7"
-    values.chart.helm.kubeaddons.mesosphere.io/traefik: "https://raw.githubusercontent.com/mesosphere/charts/984fef43d4e65aa4c48753d2dbf2420789c7d1a7/staging/traefik/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/traefik: "https://raw.githubusercontent.com/mesosphere/charts/00b019ef3610ca8221a8cf283b4d7046a50702c4/staging/traefik/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -21,7 +21,7 @@ spec:
   chartReference:
     chart: traefik
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.72.18
+    version: 1.72.19
     values: |
       ---
       replicas: 2
@@ -100,10 +100,6 @@ spec:
           port: 9000
           protocol: TCP
           targetPort: 9000
-      extraConfigEntrypoints: |
-        [entryPoints.velero-minio]
-        address = ":9000"
-          [entryPoints.velero-minio.tls]
-          [entryPoints.velero-minio.tls.defaultCertificate]
-          certFile = "/ssl/tls.crt"
-          keyFile = "/ssl/tls.key"
+      extraSSLEntrypoints:
+        velero-minio:
+          address: ":9000"

--- a/addons/traefik/1.7.x/traefik-10.yaml
+++ b/addons/traefik/1.7.x/traefik-10.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: traefik
+  labels:
+    kubeaddons.mesosphere.io/name: traefik
+    kubeaddons.mesosphere.io/provides: ingresscontroller
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.7.23-9"
+    appversion.kubeaddons.mesosphere.io/traefik: "1.7.23"
+    endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
+    docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/v1.7"
+    values.chart.helm.kubeaddons.mesosphere.io/traefik: "https://raw.githubusercontent.com/mesosphere/charts/984fef43d4e65aa4c48753d2dbf2420789c7d1a7/staging/traefik/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: cert-manager
+  chartReference:
+    chart: traefik
+    repo: https://mesosphere.github.io/charts/staging
+    version: 1.72.18
+    values: |
+      ---
+      replicas: 2
+      service:
+        labels:
+          servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
+      resources:
+        limits:
+          cpu: 1000m
+        requests:
+          cpu: 500m
+      rbac:
+        enabled: true
+      metrics:
+        prometheus:
+          enabled: true
+      dashboard:
+        enabled: true
+        domain: ""
+        serviceType: ClusterIP
+        ingress:
+          path: /ops/portal/traefik
+          annotations:
+            kubernetes.io/ingress.class: traefik
+            traefik.frontend.rule.type: PathPrefixStrip
+            traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User,Authorization,Impersonate-User,Impersonate-Group
+            traefik.ingress.kubernetes.io/auth-type: forward
+            traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
+            traefik.ingress.kubernetes.io/priority: "2"
+      kubernetes:
+        ingressEndpoint:
+          publishedService: "kubeaddons/traefik-kubeaddons"
+      ssl:
+        enabled: true
+        enforced: true
+        # TODO: This comment is no longer true.
+        # dex service is exposed with TLS certificate signed by self signed root
+        # Dex CA certificate. It is not clear if traefik supports configuring
+        # trusted certificates per backend. This should be investiaged in a
+        # separate issue.
+        # See: https://jira.mesosphere.com/browse/DCOS-56033
+        insecureSkipVerify: true
+        # We use cert-manager to automate certificate management thus we
+        # do not need the default cert secret.
+        useCertManager: true
+      deploymentAnnotations:
+        # Watching this CM will trigger traefik init container that updates certificate
+        # object with new DNS names. That will cascade secret update which will trigger
+        # another reload.
+        configmap.reloader.stakater.com/reload: konvoyconfig-kubeaddons
+        secret.reloader.stakater.com/reload: traefik-kubeaddons-certificate
+
+      initContainers:
+      - name: initialize-traefik-certificate
+        image: mesosphere/kubeaddons-addon-initializer:v0.2.9
+        args: ["traefik"]
+        env:
+        - name: "TRAEFIK_INGRESS_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TRAEFIK_INGRESS_SERVICE_NAME"
+          value: "traefik-kubeaddons"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_NAME"
+          value: "traefik-kubeaddons"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_ISSUER"
+          value: "kubernetes-ca"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_SECRET_NAME"
+          value: "traefik-kubeaddons-certificate"
+        - name: "TRAEFIK_KONVOY_ADDONS_CONFIG_MAP"
+          value: "konvoyconfig-kubeaddons"
+        - name: "TRAEFIK_CLUSTER_HOSTNAME_KEY"
+          value: "clusterHostname"
+
+      initCertJobImage: mesosphere/kubeaddons-addon-initializer:v0.2.9
+      extraServicePorts:
+        - name: velero-minio
+          port: 9000
+          protocol: TCP
+          targetPort: 9000
+      extraConfigEntrypoints: |
+        [entryPoints.velero-minio]
+        address = ":9000"
+          [entryPoints.velero-minio.tls]
+          [entryPoints.velero-minio.tls.defaultCertificate]
+          certFile = "/ssl/tls.crt"
+          keyFile = "/ssl/tls.key"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
The chart change improves the charts by allowing extra SSL entrypoints
being defined, and inherit SSL configurations from global SSL config. We
observed that in some customer environment, they are using advanced
configurations for their ingress, including turning on proxy protocol on
the ingress.
    
Previously, we use `extraConfigEntrypoints` to add the additional velero
minio entrypoints for the velero addon. This basically means if they
have any customization on the ingress entrypoint, we'll have to ask them
to manually specifying those configs `extraConfigEntrypoints` again for
the velero-minio entrypoint, which creates a very bad user experience.
    
This chart change improves this experiecne by introducing
`extraSSLEntrypoints` that will inherit global configurations so that
the user does not have to do anything on the additional entrypoints.
    
This patch update the Addon config accordingly to use the new
`extraSSLEntrypoints`.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-68705

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[traefik] fix the velero-minio entrypoint to inherit global ssl and proxy protocol configurations 
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
