### PR TITLE
chore: bump awsebscsiprovisioner to chart 0.3.8

### DIFF
--- a/addons/awsebscsiprovisioner/0.5.x/awsebscsiprovisioner-4.yaml
+++ b/addons/awsebscsiprovisioner/0.5.x/awsebscsiprovisioner-4.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: awsebscsiprovisioner
+  labels:
+    kubeaddons.mesosphere.io/name: awsebscsiprovisioner
+    kubeaddons.mesosphere.io/provides: storageclass
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.5.0-4"
+    appversion.kubeaddons.mesosphere.io/awsebscsiprovisioner: "0.5.0"
+    values.chart.helm.kubeaddons.mesosphere.io/awsebscsiprovisioner: "https://raw.githubusercontent.com/mesosphere/charts/957337e/stable/awsebscsiprovisioner/values.yaml"
+spec:
+  namespace: kube-system
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: defaultstorageclass-protection
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+  chartReference:
+    version: 0.3.8
+    chart: awsebscsiprovisioner
+    repo: https://mesosphere.github.io/charts/stable
+    values: |
+      ---
+      resizer:
+        enabled: true
+      snapshotter:
+        enabled: true
+      provisioner:
+        enableVolumeScheduling: true
+      storageclass:
+        isDefault: true
+        reclaimPolicy: Delete
+        volumeBindingMode: WaitForFirstConsumer
+        type: gp2
+        fstype: ext4
+        iopsPerGB: null
+        encrypted: false
+        kmsKeyId: null
+        allowedTopologies: []
+        # - matchLabelExpressions:
+        #   - key: topology.ebs.csi.aws.com/zone
+        #     values:
+        #     - us-west-2a
+        #     - us-west-2b
+        #     - us-west-2c
+        allowVolumeExpansion: true
+      # replicas of the CSI-Controller
+      replicas: 1
+      statefulSetCSIController:
+      # if you want to use kube2iam or kiam roles define it here as podAnnotation for the CSI-Controller (statefulSet)
+        podAnnotations: {}
+      statefulSetCSISnapshotController:
+        # if you want to use kube2iam or kiam roles define it here as podAnnotation for the CSI-Snapshot-Controller (statefulSet)
+        podAnnotations: {}
+      # Extra volume tags to attach to each dynamically provisioned volume.
+      # ---
+      # extraVolumeTags:
+      #   key1: value1
+      #   key2: value2
+      extraVolumeTags: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Backport #275 to testing branch

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-68987

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[awsebscsiprovisioner] The manual steps to upgrade the snapshot APIs from v1alpha1 to v1beta1 is no longer required. It has been automated in the chart CRD install hook by default. If you do not want that default behavior of cleaning up v1alpha1 snapshot CRDs, you can set `cleanupVolumeSnapshotCRDV1alpha1` to `false` and follow the instructions for upgrading to Kubernetes `1.17`.
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
