### PR TITLE
chore: added resource requests for ephemeral storage.

### DIFF
--- a/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-8.yaml
+++ b/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-8.yaml
@@ -40,6 +40,7 @@ spec:
         requests:
           cpu: 100m
           memory: 128Mi
+          ephemeral-storage: 200Mi
       service:
         type: ClusterIP
         port: 4181

--- a/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-8.yaml
+++ b/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-8.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta2
+kind: Addon
+metadata:
+  name: traefik-forward-auth
+  namespace: kubeaddons
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.4-7"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: dex
+    - matchLabels:
+        kubeaddons.mesosphere.io/provides: ingresscontroller
+  chartReference:
+    chart: traefik-forward-auth
+    repo: https://mesosphere.github.io/charts/staging
+    version: 0.2.13
+    values: |
+      ---
+      replicaCount: 1
+      image:
+        repository: mesosphere/traefik-forward-auth
+        tag: 2.0.5
+        pullPolicy: IfNotPresent
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      service:
+        type: ClusterIP
+        port: 4181
+      traefikForwardAuth:
+        # oidcUri will be overridden by the init-container
+        oidcUri: "https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex"
+        clientId: traefik-forward-auth
+        clientSecret:
+          valueFrom:
+            secretKeyRef:
+              name: dex-client-secret-traefik-forward-auth
+              key: client_secret
+        cookieSecure: true
+        userCookieName: "konvoy_profile_name"
+        extraConfig:
+          auth-host = dex-kubeaddons.kubeaddons.svc.cluster.local:8080
+        enableRBAC: true
+        enableImpersonation: true
+        rbacPassThroughPaths: ["/ops/portal/kubernetes/", "/ops/portal/kubernetes/*"]
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.class: traefik
+          ingress.kubernetes.io/protocol: https
+          traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User,Impersonate-User,Impersonate-Group
+          traefik.ingress.kubernetes.io/auth-type: forward
+          traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
+          traefik.ingress.kubernetes.io/priority: "1"
+        paths:
+          - /_oauth
+        hosts:
+          - ""
+        tls: []
+      deploymentAnnotations:
+        # The certificate can change because it was rotated or different cluster
+        # DNS name has been set.
+        secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate,dex-kubeaddons"
+      initContainers:
+      # initialize-traefik-forward-auth deploys credentials for use by the proxy
+      - name: initialize-traefik-forward-auth
+        image: mesosphere/kubeaddons-addon-initializer:v0.2.9
+        args: ["traefikforwardauth"]
+        env:
+        - name: "TFA_CONFIGMAP_NAME"
+          value: "traefik-forward-auth-kubeaddons-configmap"
+        - name: "TFA_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TFA_INGRESS_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TFA_INGRESS_SERVICE_NAME"
+          value: "traefik-kubeaddons"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Adds a resource request for ephemeral storage to the traefik-forward-auth Addon. Without such request the addon is constantly at risk of getting evicted when disk-space gets scarce.

When observing this Addon on our test-cluster we were able to see that it commonly hovers around 15mb ephemeral disk use. 99% of that space is occupied by logs which are getting rotated out. Given these demands and adding some buffer leads to the idea that 200mb should be more than enough for this Addon to remain stable in all situations.

See these measurements:
```
  "ephemeral-storage": {
    "time": "2020-06-02T22:51:13Z",
    "availableBytes": 84235845632,
    "capacityBytes": 85887791104,
    "usedBytes": 15909280,
    "inodesFree": 41913997,
    "inodes": 41942512,
    "inodesUsed": 35
   }
```

```
     "logs": {
      "time": "2020-06-02T22:51:13Z",
      "availableBytes": 84235845632,
      "capacityBytes": 85887791104,
      "usedBytes": 15900672,
      "inodesFree": 41913997,
      "inodes": 41942512,
      "inodesUsed": 6
     }
```
```
   "ephemeral-storage": {
    "time": "2020-06-03T00:32:24Z",
    "availableBytes": 84205379584,
    "capacityBytes": 85887791104,
    "usedBytes": 15851936,
    "inodesFree": 41913991,
    "inodes": 41942512,
    "inodesUsed": 35
```

```
   "ephemeral-storage": {
    "time": "2020-06-03T00:41:52Z",
    "availableBytes": 84192649216,
    "capacityBytes": 85887791104,
    "usedBytes": 28434848,
    "inodesFree": 41913991,
    "inodes": 41942512,
    "inodesUsed": 35
   }
```

```
   "ephemeral-storage": {
    "time": "2020-06-03T00:47:59Z",
    "availableBytes": 84207382528,
    "capacityBytes": 85887791104,
    "usedBytes": 13717920,
    "inodesFree": 41913991,
    "inodes": 41942512,
    "inodesUsed": 35
   }
```

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-68096

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The traefik-foward-auth addon now requests 200mb of ephemeral space.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
