### PR TITLE
Bump gcp/azure disk csi driver to support auto upgrade

### DIFF
--- a/addons/azuredisk-csi-driver/0.7.x/azuredisk-csi-driver-3.yaml
+++ b/addons/azuredisk-csi-driver/0.7.x/azuredisk-csi-driver-3.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: azuredisk-csi-driver
+  labels:
+    kubeaddons.mesosphere.io/name: azuredisk-csi-driver
+    kubeaddons.mesosphere.io/provides: csi-driver
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.7.1-1"
+    appversion.kubeaddons.mesosphere.io/azuredisk-csi-driver: "0.7.1"
+    values.chart.helm.kubeaddons.mesosphere.io/azuredisk-csi-driver: "https://raw.githubusercontent.com/mesosphere/charts/98d5bee/stable/azuredisk-csi-driver/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  namespace: kube-system
+  cloudProvider:
+    - name: azure
+      enabled: true
+  chartReference:
+    chart: azuredisk-csi-driver
+    repo: https://mesosphere.github.io/charts/stable
+    version: 0.7.1

--- a/addons/azuredisk-csi-driver/0.7.x/azuredisk-csi-driver-3.yaml
+++ b/addons/azuredisk-csi-driver/0.7.x/azuredisk-csi-driver-3.yaml
@@ -7,9 +7,9 @@ metadata:
     kubeaddons.mesosphere.io/name: azuredisk-csi-driver
     kubeaddons.mesosphere.io/provides: csi-driver
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.7.1-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.7.1-2"
     appversion.kubeaddons.mesosphere.io/azuredisk-csi-driver: "0.7.1"
-    values.chart.helm.kubeaddons.mesosphere.io/azuredisk-csi-driver: "https://raw.githubusercontent.com/mesosphere/charts/98d5bee/stable/azuredisk-csi-driver/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/azuredisk-csi-driver: "https://raw.githubusercontent.com/mesosphere/charts/68420c0ec86604d5abab5e635fd9ab4123ef1d07/stable/azuredisk-csi-driver/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -20,4 +20,4 @@ spec:
   chartReference:
     chart: azuredisk-csi-driver
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.7.1
+    version: 0.7.2

--- a/addons/gcpdisk-csi-driver/0.7.x/gcpdisk-csi-driver-3.yaml
+++ b/addons/gcpdisk-csi-driver/0.7.x/gcpdisk-csi-driver-3.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: gcpdisk-csi-driver
+  labels:
+    kubeaddons.mesosphere.io/name: gcpdisk-csi-driver
+    kubeaddons.mesosphere.io/provides: csi-driver
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.7.1-1"
+    appversion.kubeaddons.mesosphere.io/gcpdisk-csi-driver: "0.7.1"
+    values.chart.helm.kubeaddons.mesosphere.io/gcpdisk-csi-driver: "https://raw.githubusercontent.com/mesosphere/charts/e131e22/stable/gcpdisk-csi-driver/values.yaml"
+spec:
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: defaultstorageclass-protection
+  kubernetes:
+    minSupportedVersion: v1.15.0
+  namespace: kube-system
+  cloudProvider:
+    - name: gcp
+      enabled: true
+  chartReference:
+    chart: gcpdisk-csi-driver
+    repo: https://mesosphere.github.io/charts/stable
+    version: 0.7.1

--- a/addons/gcpdisk-csi-driver/0.7.x/gcpdisk-csi-driver-3.yaml
+++ b/addons/gcpdisk-csi-driver/0.7.x/gcpdisk-csi-driver-3.yaml
@@ -7,9 +7,9 @@ metadata:
     kubeaddons.mesosphere.io/name: gcpdisk-csi-driver
     kubeaddons.mesosphere.io/provides: csi-driver
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.7.1-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.7.1-2"
     appversion.kubeaddons.mesosphere.io/gcpdisk-csi-driver: "0.7.1"
-    values.chart.helm.kubeaddons.mesosphere.io/gcpdisk-csi-driver: "https://raw.githubusercontent.com/mesosphere/charts/e131e22/stable/gcpdisk-csi-driver/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/gcpdisk-csi-driver: "https://raw.githubusercontent.com/mesosphere/charts/c77ea20ce5900b001c0f5934c644594e8a748acd/stable/gcpdisk-csi-driver/values.yaml"
 spec:
   requires:
     - matchLabels:
@@ -23,4 +23,4 @@ spec:
   chartReference:
     chart: gcpdisk-csi-driver
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.7.1
+    version: 0.7.2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Pickup changes in to make the upgrade automatic on azure/gcp w.r.t. their csi drivers.
https://github.com/mesosphere/charts/pull/616
https://github.com/mesosphere/charts/pull/618

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-68987

**Special notes for your reviewer**:
Since we haven't setup CI for gcp/azure e2e yet for kba, i manually created this konvoy PR to test ci: https://github.com/mesosphere/konvoy/pull/1627

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[gcpdisk-csi-driver] The manual steps to upgrade the snapshot APIs from v1alpha1 to v1beta1 is no longer required. It has been automated in the chart CRD install hook by default. If you do not want that default behavior of cleaning up v1alpha1 snapshot CRDs, you can set `cleanupVolumeSnapshotCRDV1alpha1` to `false` and follow the instructions for upgrading to Kubernetes `1.17`.
[azuredisk-csi-driver] The manual steps to upgrade the snapshot APIs from v1alpha1 to v1beta1 is no longer required. It has been automated in the chart CRD install hook by default. If you do not want that default behavior of cleaning up v1alpha1 snapshot CRDs, you can set `snapshot.cleanupVolumeSnapshotCRDV1alpha1` to `false` and follow the instructions for upgrading to Kubernetes `1.17`.
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
