### PR TITLE
Configure Traefik to improve availability

### DIFF
--- a/addons/traefik/1.7.x/traefik-11.yaml
+++ b/addons/traefik/1.7.x/traefik-11.yaml
@@ -7,7 +7,7 @@ metadata:
     kubeaddons.mesosphere.io/name: traefik
     kubeaddons.mesosphere.io/provides: ingresscontroller
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.7.23-10"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.7.23-11"
     appversion.kubeaddons.mesosphere.io/traefik: "1.7.23"
     endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
     docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/v1.7"

--- a/addons/traefik/1.7.x/traefik-12.yaml
+++ b/addons/traefik/1.7.x/traefik-12.yaml
@@ -7,7 +7,7 @@ metadata:
     kubeaddons.mesosphere.io/name: traefik
     kubeaddons.mesosphere.io/provides: ingresscontroller
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.7.23-11"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.7.23-12"
     appversion.kubeaddons.mesosphere.io/traefik: "1.7.23"
     endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
     docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/v1.7"

--- a/addons/traefik/1.7.x/traefik-12.yaml
+++ b/addons/traefik/1.7.x/traefik-12.yaml
@@ -49,7 +49,7 @@ spec:
                   operator: In
                   values:
                   - traefik-kubeaddons
-              topologyKey: topology.kubernetes.io/zone
+              topologyKey: failure-domain.beta.kubernetes.io/zone
       service:
         labels:
           servicemonitor.kubeaddons.mesosphere.io/path: "metrics"

--- a/addons/traefik/1.7.x/traefik-12.yaml
+++ b/addons/traefik/1.7.x/traefik-12.yaml
@@ -24,7 +24,32 @@ spec:
     version: 1.72.19
     values: |
       ---
+      # Configure Traefik for HA.
       replicas: 2
+      podDisruptionBudget:
+        minAvailable: 1
+      # Distribute pods to tolerate node or zone failure.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: release
+                  operator: In
+                  values:
+                  - traefik-kubeaddons
+              topologyKey: kubernetes.io/hostname
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: release
+                  operator: In
+                  values:
+                  - traefik-kubeaddons
+              topologyKey: topology.kubernetes.io/zone
       service:
         labels:
           servicemonitor.kubeaddons.mesosphere.io/path: "metrics"

--- a/addons/traefik/1.7.x/traefik-12.yaml
+++ b/addons/traefik/1.7.x/traefik-12.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: traefik
+  labels:
+    kubeaddons.mesosphere.io/name: traefik
+    kubeaddons.mesosphere.io/provides: ingresscontroller
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.7.23-11"
+    appversion.kubeaddons.mesosphere.io/traefik: "1.7.23"
+    endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
+    docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/v1.7"
+    values.chart.helm.kubeaddons.mesosphere.io/traefik: "https://raw.githubusercontent.com/mesosphere/charts/00b019ef3610ca8221a8cf283b4d7046a50702c4/staging/traefik/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: cert-manager
+  chartReference:
+    chart: traefik
+    repo: https://mesosphere.github.io/charts/staging
+    version: 1.72.19
+    values: |
+      ---
+      replicas: 2
+      service:
+        labels:
+          servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
+      resources:
+        limits:
+          cpu: 1000m
+        requests:
+          cpu: 500m
+      rbac:
+        enabled: true
+      metrics:
+        prometheus:
+          enabled: true
+      dashboard:
+        enabled: true
+        domain: ""
+        serviceType: ClusterIP
+        ingress:
+          path: /ops/portal/traefik
+          annotations:
+            kubernetes.io/ingress.class: traefik
+            traefik.frontend.rule.type: PathPrefixStrip
+            traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User,Authorization,Impersonate-User,Impersonate-Group
+            traefik.ingress.kubernetes.io/auth-type: forward
+            traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
+            traefik.ingress.kubernetes.io/priority: "2"
+      kubernetes:
+        ingressEndpoint:
+          publishedService: "kubeaddons/traefik-kubeaddons"
+      ssl:
+        enabled: true
+        enforced: true
+        # TODO: This comment is no longer true.
+        # dex service is exposed with TLS certificate signed by self signed root
+        # Dex CA certificate. It is not clear if traefik supports configuring
+        # trusted certificates per backend. This should be investiaged in a
+        # separate issue.
+        # See: https://jira.mesosphere.com/browse/DCOS-56033
+        insecureSkipVerify: true
+        # We use cert-manager to automate certificate management thus we
+        # do not need the default cert secret.
+        useCertManager: true
+      deploymentAnnotations:
+        # Watching this CM will trigger traefik init container that updates certificate
+        # object with new DNS names. That will cascade secret update which will trigger
+        # another reload.
+        configmap.reloader.stakater.com/reload: konvoyconfig-kubeaddons
+        secret.reloader.stakater.com/reload: traefik-kubeaddons-certificate
+
+      initContainers:
+      - name: initialize-traefik-certificate
+        image: mesosphere/kubeaddons-addon-initializer:v0.2.10
+        args: ["traefik"]
+        env:
+        - name: "TRAEFIK_INGRESS_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TRAEFIK_INGRESS_SERVICE_NAME"
+          value: "traefik-kubeaddons"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_NAME"
+          value: "traefik-kubeaddons"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_ISSUER"
+          value: "kubernetes-ca"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_SECRET_NAME"
+          value: "traefik-kubeaddons-certificate"
+        - name: "TRAEFIK_KONVOY_ADDONS_CONFIG_MAP"
+          value: "konvoyconfig-kubeaddons"
+        - name: "TRAEFIK_CLUSTER_HOSTNAME_KEY"
+          value: "clusterHostname"
+
+      initCertJobImage: mesosphere/kubeaddons-addon-initializer:v0.2.10
+      extraServicePorts:
+        - name: velero-minio
+          port: 9000
+          protocol: TCP
+          targetPort: 9000
+      extraSSLEntrypoints:
+        velero-minio:
+          address: ":9000"

--- a/addons/traefik/1.7.x/traefik-12.yaml
+++ b/addons/traefik/1.7.x/traefik-12.yaml
@@ -36,20 +36,23 @@ spec:
             podAffinityTerm:
               labelSelector:
                 matchExpressions:
-                - key: release
+                - key: kubeaddons.mesosphere.io/name
                   operator: In
                   values:
-                  - traefik-kubeaddons
+                  - traefik
               topologyKey: kubernetes.io/hostname
           - weight: 1
             podAffinityTerm:
               labelSelector:
                 matchExpressions:
-                - key: release
+                - key: kubeaddons.mesosphere.io/name
                   operator: In
                   values:
-                  - traefik-kubeaddons
+                  - traefik
               topologyKey: failure-domain.beta.kubernetes.io/zone
+      deployment:
+        podLabels:
+          kubeaddons.mesosphere.io/name: traefik
       service:
         labels:
           servicemonitor.kubeaddons.mesosphere.io/path: "metrics"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This configures the Traefik helm chart to better ensure Traefik's availability. This PR adds a PodDisruptionBudget to ensure at least 1 Traefik pod is running at all times, and distributes Traefik pods in order to tolerate the failure of a node or zone. The affinity that causes pods to distribute across nodes or zones is declared as a preference, so the pods will colocate on a node or zone if there aren't enough for an even distribution. 

This PR also adds a bump to the latest Traefik addon revision that was missing from https://github.com/mesosphere/kubernetes-base-addons/pull/286.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-67944

**Special notes for your reviewer**:

I tested this PR by deploying Konvoy with the kubernetes-base-addons configversion set to this branch, and with worker nodes in two different availability zones. After the cluster came up I observed that the traefik pods were running on different nodes in different zones. I then drained all but one worker node, and observed that the traefik pods were rescheduled to that remaining node.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
\[traefik\] Distribute pods across nodes and zones when possible.
\[traefik\] Set a PodDisruptionBudget to ensure at least 1 pod is running at all times.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
