### PR TITLE
chore: bump istio from 1.5.x to 1.6.x

### DIFF
--- a/addons/istio/1.6.x/istio-1.yaml
+++ b/addons/istio/1.6.x/istio-1.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: istio
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.4-1"
-    appversion.kubeaddons.mesosphere.io/istio: "1.5.4"
-    appversion.kubeaddons.mesosphere.io/kiali: "1.15.1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.3-1"
+    appversion.kubeaddons.mesosphere.io/istio: "1.6.3"
+    appversion.kubeaddons.mesosphere.io/kiali: "1.18.0"
     appversion.kubeaddons.mesosphere.io/jaeger: "1.16.0"
     stage.kubeaddons.mesosphere.io/kiali: Preview
     stage.kubeaddons.mesosphere.io/jaeger: Preview
@@ -17,6 +17,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/istio: "https://istio.io/docs/"
     docs.kubeaddons.mesosphere.io/kiali: "https://istio.io/docs/tasks/telemetry/kiali/"
     docs.kubeaddons.mesosphere.io/jaeger: "https://istio.io/docs/tasks/telemetry/distributed-tracing/jaeger/"
+    values.chart.helm.kubeaddons.mesosphere.io/istio: "https://raw.githubusercontent.com/mesosphere/charts/63bbc17eda76f2136f6ab4f6d6eef7e764e5f0a5/staging/istio/values.yaml"
 spec:
   namespace: istio-system
   requires:
@@ -33,8 +34,31 @@ spec:
       enabled: false
     - name: none
       enabled: false
-  kudoReference:
-    package: istio-operator
-    repo: https://kudo-private.storage.googleapis.com
-    version: 0.1.0
-    appVersion: 1.5.4
+  chartReference:
+    chart: istio
+    repo: https://mesosphere.github.io/charts/staging
+    version: 1.6.3
+    values: |
+      istioOperator:
+        addonComponents:
+          kiali:
+            enabled: true
+          tracing:
+            enabled: true 
+
+        values:
+          global:
+            defaultPodDisruptionBudget:
+              enabled: false
+
+          kiali:
+            contextPath: /ops/portal/kiali
+            dashboard:
+              auth:
+                strategy: anonymous
+              grafanaInClusterURL: http://prometheus-kubeaddons-grafana.kubeaddons:3000
+              jaegerInClusterURL: http://tracing/jaeger
+            prometheusAddr: http://prometheus-kubeaddons-prom-prometheus.kubeaddons:9090
+
+          tracing:
+            contextPath: /ops/portal/jaeger

--- a/addons/istio/1.6.x/istio-1.yaml
+++ b/addons/istio/1.6.x/istio-1.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: istio
+  labels:
+    kubeaddons.mesosphere.io/name: istio
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.4-1"
+    appversion.kubeaddons.mesosphere.io/istio: "1.5.4"
+    appversion.kubeaddons.mesosphere.io/kiali: "1.15.1"
+    appversion.kubeaddons.mesosphere.io/jaeger: "1.16.0"
+    stage.kubeaddons.mesosphere.io/kiali: Preview
+    stage.kubeaddons.mesosphere.io/jaeger: Preview
+    endpoint.kubeaddons.mesosphere.io/kiali: "/ops/portal/kiali"
+    endpoint.kubeaddons.mesosphere.io/jaeger: "/ops/portal/jaeger"
+    docs.kubeaddons.mesosphere.io/istio: "https://istio.io/docs/"
+    docs.kubeaddons.mesosphere.io/kiali: "https://istio.io/docs/tasks/telemetry/kiali/"
+    docs.kubeaddons.mesosphere.io/jaeger: "https://istio.io/docs/tasks/telemetry/distributed-tracing/jaeger/"
+spec:
+  namespace: istio-system
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: cert-manager
+  kubernetes:
+    minSupportedVersion: v1.16.0
+  cloudProvider:
+    - name: aws
+      enabled: false
+    - name: azure
+      enabled: false
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: false
+  kudoReference:
+    package: istio-operator
+    repo: https://kudo-private.storage.googleapis.com
+    version: 0.1.0
+    appVersion: 1.5.4


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
Chore

**What this PR does/ why we need it**:
This PR move istio installation from KUDO back to helm. In the process it also upgrade it from 1.5.x to 1.6.x

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-69720

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
istio addon upgraded to 1.6.3

```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
