### PR TITLE
tfa: remove valuesRemap for /_oauth endpoint

### DIFF
--- a/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-7.yaml
+++ b/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-7.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta2
+kind: Addon
+metadata:
+  name: traefik-forward-auth
+  namespace: kubeaddons
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.4-6"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: dex
+    - matchLabels:
+        kubeaddons.mesosphere.io/provides: ingresscontroller
+  chartReference:
+    chart: traefik-forward-auth
+    repo: https://mesosphere.github.io/charts/staging
+    valuesRemap:
+      "ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
+    version: 0.2.13
+    values: |
+      ---
+      replicaCount: 1
+      image:
+        repository: mesosphere/traefik-forward-auth
+        tag: 2.0.5
+        pullPolicy: IfNotPresent
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      service:
+        type: ClusterIP
+        port: 4181
+      traefikForwardAuth:
+        # oidcUri will be overridden by the init-container
+        oidcUri: "https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex"
+        clientId: traefik-forward-auth
+        clientSecret:
+          valueFrom:
+            secretKeyRef:
+              name: dex-client-secret-traefik-forward-auth
+              key: client_secret
+        cookieSecure: true
+        userCookieName: "konvoy_profile_name"
+        extraConfig:
+          auth-host = dex-kubeaddons.kubeaddons.svc.cluster.local:8080
+        enableRBAC: true
+        enableImpersonation: true
+        rbacPassThroughPaths: ["/ops/portal/kubernetes/", "/ops/portal/kubernetes/*"]
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.class: traefik
+          ingress.kubernetes.io/protocol: https
+          traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User,Impersonate-User,Impersonate-Group
+          traefik.ingress.kubernetes.io/auth-type: forward
+          traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
+          traefik.ingress.kubernetes.io/priority: "1"
+        paths:
+          - /_oauth
+        hosts:
+          - ""
+        tls: []
+      deploymentAnnotations:
+        # The certificate can change because it was rotated or different cluster
+        # DNS name has been set.
+        secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate,dex-kubeaddons"
+      initContainers:
+      # initialize-traefik-forward-auth deploys credentials for use by the proxy
+      - name: initialize-traefik-forward-auth
+        image: mesosphere/kubeaddons-addon-initializer:v0.2.9
+        args: ["traefikforwardauth"]
+        env:
+        - name: "TFA_CONFIGMAP_NAME"
+          value: "traefik-forward-auth-kubeaddons-configmap"
+        - name: "TFA_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TFA_INGRESS_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TFA_INGRESS_SERVICE_NAME"
+          value: "traefik-kubeaddons"

--- a/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-7.yaml
+++ b/addons/traefik-forward-auth/1.0.x/traefik-forward-auth-7.yaml
@@ -5,7 +5,7 @@ metadata:
   name: traefik-forward-auth
   namespace: kubeaddons
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.4-6"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.4-7"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -28,8 +28,6 @@ spec:
   chartReference:
     chart: traefik-forward-auth
     repo: https://mesosphere.github.io/charts/staging
-    valuesRemap:
-      "ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
     version: 0.2.13
     values: |
       ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
There is no point to change the traefik forward auth auth-url for
/_oauth endpoint using valuesRemap since this endpoint is dedicated for
this instance of TFA. This is the flow:
    
1. A user accesses /ops/portal
2. Traefik redirects to TFA for authn and authz
3. TFA talks to dex at /dex/auth
4. Login flow
5. Dex calls back at /_oauth
6. Traefik redirects to the *same* TFA for authn and authz
7. Token, user and CSRF cookie is validated (this request in intercepted)

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-69846

**Special notes for your reviewer**:

Manually verified that the problem goes away after self attaching.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
traefik-foward-auth: fix a bug that might cause /_oauth callback to be redirected to other services
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
