### PR TITLE
chore: bump external-dns version and also disable it by default

### DIFF
--- a/addons/external-dns/0.7.x/external-dns-1.yaml
+++ b/addons/external-dns/0.7.x/external-dns-1.yaml
@@ -6,19 +6,15 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: external-dns
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.5.18-1"
-    appversion.kubeaddons.mesosphere.io/external-dns: "0.5.18"
-    values.chart.helm.kubeaddons.mesosphere.io/external-dns: "https://raw.githubusercontent.com/helm/charts/4f38b11/stable/external-dns/values-production.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.7.0-1"
+    appversion.kubeaddons.mesosphere.io/external-dns: "0.7.0"
+    values.chart.helm.kubeaddons.mesosphere.io/external-dns: "https://raw.githubusercontent.com/helm/charts/b9191a5b526d4988b7938be2049370a1687037a0/stable/external-dns/values-production.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
   cloudProvider:
     - name: aws
-      enabled: true
-      values: |
-        aws:
-          region:
-        domainFilters: []
+      enabled: false
     - name: azure
       enabled: false
     - name: gcp
@@ -29,7 +25,7 @@ spec:
       enabled: false
   chartReference:
     chart: stable/external-dns
-    version: 2.16.1
+    version: 2.20.4
     values: |
       rbac:
         create: true

--- a/addons/external-dns/0.7.x/external-dns-1.yaml
+++ b/addons/external-dns/0.7.x/external-dns-1.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: external-dns
+  labels:
+    kubeaddons.mesosphere.io/name: external-dns
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.5.18-1"
+    appversion.kubeaddons.mesosphere.io/external-dns: "0.5.18"
+    values.chart.helm.kubeaddons.mesosphere.io/external-dns: "https://raw.githubusercontent.com/helm/charts/4f38b11/stable/external-dns/values-production.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+      values: |
+        aws:
+          region:
+        domainFilters: []
+    - name: azure
+      enabled: false
+    - name: gcp
+      enabled: false
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: false
+  chartReference:
+    chart: stable/external-dns
+    version: 2.16.1
+    values: |
+      rbac:
+        create: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
Chore

**What this PR does/ why we need it**:
External-dns isn't configured to be usable by default. Hence, it make sense to disable it. This patch disable external-dns by default. Besides, it also updates the chart version

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-69859

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
external-dns is disabled by default 

```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
