### PR TITLE
[debugging daily] fix: prometheus cpu values

### DIFF
--- a/addons/prometheus/0.38.x/prometheus-9.yaml
+++ b/addons/prometheus/0.38.x/prometheus-9.yaml
@@ -10,7 +10,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.38.1-9"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.38.1-10"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.38.1"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.19.2"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.20.0"
@@ -262,10 +262,10 @@ spec:
         alertmanagerSpec:
           resources:
             limits:
-              cpu: 2
+              cpu: 2000m
               memory: 8Gi
             requests:
-              cpu: 1
+              cpu: 1000m
               memory: 4Gi
       grafana:
         ingress:


### PR DESCRIPTION
Error: failed to create resource: Alertmanager.monitoring.coreos.com \"prometheus-kubeaddons-prom-alertmanager\" is invalid: [spec.resources.limits.cpu: Invalid value: \"integer\": spec.resources.limits.cpu in body must be of type string: \"integer\",

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
