### PR TITLE
chore: bump opsportal chart

### DIFF
--- a/addons/opsportal/1.1.x/opsportal-12.yaml
+++ b/addons/opsportal/1.1.x/opsportal-12.yaml
@@ -10,7 +10,7 @@ metadata:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-12"
     appversion.kubeaddons.mesosphere.io/opsportal: "1.1.0"
     endpoint.kubeaddons.mesosphere.io/opsportal: /ops/portal/
-    values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/132c1662f1/stable/opsportal/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/6c5e399d3ac34a9fdf65cc26c577d5ab54c39be3/stable/opsportal/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6

--- a/addons/opsportal/1.1.x/opsportal-12.yaml
+++ b/addons/opsportal/1.1.x/opsportal-12.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta2
+kind: Addon
+metadata:
+  name: opsportal
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: opsportal
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-11"
+    appversion.kubeaddons.mesosphere.io/opsportal: "1.1.0"
+    endpoint.kubeaddons.mesosphere.io/opsportal: /ops/portal/
+    values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/132c1662f1/stable/opsportal/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  chartReference:
+    chart: opsportal
+    repo: https://mesosphere.github.io/charts/stable
+    version: 0.3.19
+    valuesRemap:
+      "kommander-ui.ingress.extraAnnotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
+    values: |
+      ---
+      landing:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      opsportalRBAC:
+        enabled: true
+        path: /ops/portal
+        graphqlPath: /ops/portal/graphql
+        ## traefik-forward-auth 2.0 introduces RBAC support and now requires that users, regardless of whitelist,
+        ## be allowed access to a resource via explicit RBAC policy. Upon upgrade, whitelisted users would no longer
+        ## have access to ops portal resources unless an appropriate role binding existed. To prevent breakage,
+        ## the allowAllAuthenticated option, when true, will result in the group `system:authenticated` being bound to
+        ## to the opsportal-admin role. This mimics the existing security policy where any authenticated and whitelisted user
+        ## has full access to the opsportal. This option will be removed in the 0.3 release of this chart.
+        allowAllAuthenticated: false
+      kommander-ui:
+        enabled: true
+        # Mode must be either production|konvoy, konvoy forcing ui in "konvoy mode"
+        mode: konvoy
+        displayName: Konvoy Cluster
+        ### This must match the serviceName set in the ingress backend below
+        service:
+          name: opsportal
+        ingress:
+          enabled: true
+          traefikFrontendRuleType: PathPrefixStrip
+          path: /ops/portal
+          extraAnnotations:
+            traefik.ingress.kubernetes.io/priority: "1"
+            traefik.ingress.kubernetes.io/auth-type: forward
+            traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
+            traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User,Impersonate-User,Impersonate-Group

--- a/addons/opsportal/1.1.x/opsportal-12.yaml
+++ b/addons/opsportal/1.1.x/opsportal-12.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: opsportal
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-11"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-12"
     appversion.kubeaddons.mesosphere.io/opsportal: "1.1.0"
     endpoint.kubeaddons.mesosphere.io/opsportal: /ops/portal/
     values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/132c1662f1/stable/opsportal/values.yaml"
@@ -28,7 +28,7 @@ spec:
   chartReference:
     chart: opsportal
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.3.19
+    version: 0.3.21
     valuesRemap:
       "kommander-ui.ingress.extraAnnotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
     values: |


### PR DESCRIPTION
Depends on mesosphere/charts#686

**What type of PR is this?**
Chore

**What this PR does/ why we need it**:
Bump opsportal chart

**Which issue(s) this PR fixes**:
https://github.com/mesosphere/kommander/pull/2537 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Adds the Conductor service card to the cluster detail page of the UI.
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
