### PR TITLE
fix: fluentbit memBufLimit change

### DIFF
--- a/addons/fluentbit/1.3.x/fluentbit-5.yaml
+++ b/addons/fluentbit/1.3.x/fluentbit-5.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: fluentbit
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.7-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.7-2"
     appversion.kubeaddons.mesosphere.io/fluentbit: "1.3.7"
     values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/helm/charts/d407562/stable/fluent-bit/values.yaml"
 spec:
@@ -36,7 +36,7 @@ spec:
       audit:
         enable: true
         input:
-          memBufLimit: 35MB
+          memBufLimit: 135MB
           parser: kubernetes-audit
           path: /var/log/kubernetes/audit/*.log
           bufferChunkSize: 5MB

--- a/addons/fluentbit/1.3.x/fluentbit-5.yaml
+++ b/addons/fluentbit/1.3.x/fluentbit-5.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: fluentbit
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: fluentbit
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.7-1"
+    appversion.kubeaddons.mesosphere.io/fluentbit: "1.3.7"
+    values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/helm/charts/d407562/stable/fluent-bit/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    # This allows us to have fluentbit wait until ES is deployed and has the right configurations up, in particular
+    # setting up index templates
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: elasticsearch
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: true
+  chartReference:
+    chart: stable/fluent-bit
+    version: 2.8.17
+    values: |
+      audit:
+        enable: true
+        input:
+          memBufLimit: 35MB
+          parser: kubernetes-audit
+          path: /var/log/kubernetes/audit/*.log
+          bufferChunkSize: 5MB
+          bufferMaxSize: 20MB
+          skipLongLines: Off
+          key: kubernetes-audit
+      backend:
+        es:
+          host: elasticsearch-kubeaddons-client
+          time_key: '@ts'
+        type: es
+      filter:
+        mergeJSONLog: false
+      input:
+        tail:
+          parser: cri
+        systemd:
+          enabled: true
+          filters:
+            systemdUnit: []
+          stripUnderscores: true
+      metrics:
+        enabled: true
+        service:
+          labels:
+            servicemonitor.kubeaddons.mesosphere.io/path: "api__v1__metrics__prometheus"
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      resources:
+        limits:
+          memory: 750Mi
+        requests:
+          # values extracted from a 1 output/1 input setup here:
+          # https://github.com/fluent/fluent-bit-kubernetes-logging/blob/master/fluent-bit-daemonset-kafka-rest.yml
+          # we double it for 1 output (es)/2 input (tail, systemd) as an approximation
+          cpu: 200m
+          memory: 200Mi
+      parsers:
+        enabled: true
+        json:
+          - name: kubernetes-audit
+            timeKey: requestReceivedTimestamp
+            timeKeep: On
+            timeFormat: "%Y-%m-%dT%H:%M:%S.%L"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
- defining higher value for input audit memBufLimit as our configured default
kubernetes audit logs grow up to 100MB.
A read in of such a big file would fail and no events would get 
forwarded to elasticsearch.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
```
jql=key in (D2IQ-69770)
```

[D2IQ-69770]

[D2IQ-69770]: https://jira.d2iq.com/browse/D2IQ-69770

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fluentbit: audit memBufLimit changed to 135MB
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.