### PR TITLE
feat: adding fluent-bit official chart

### DIFF
--- a/addons/fluentbit/1.5.x/fluentbit-1.yaml
+++ b/addons/fluentbit/1.5.x/fluentbit-1.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: fluentbit
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: fluentbit
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.7-1"
+    appversion.kubeaddons.mesosphere.io/fluentbit: "1.3.7"
+    values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/helm/charts/d407562/stable/fluent-bit/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    # This allows us to have fluentbit wait until ES is deployed and has the right configurations up, in particular
+    # setting up index templates
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: elasticsearch
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: true
+  chartReference:
+    chart: stable/fluent-bit
+    version: 2.8.17
+    values: |
+      audit:
+        enable: true
+        input:
+          memBufLimit: 35MB
+          parser: kubernetes-audit
+          path: /var/log/kubernetes/audit/*.log
+          bufferChunkSize: 5MB
+          bufferMaxSize: 20MB
+          skipLongLines: Off
+          key: kubernetes-audit
+      backend:
+        es:
+          host: elasticsearch-kubeaddons-client
+          time_key: '@ts'
+        type: es
+      filter:
+        mergeJSONLog: false
+      input:
+        tail:
+          parser: cri
+        systemd:
+          enabled: true
+          filters:
+            systemdUnit: []
+          stripUnderscores: true
+      metrics:
+        enabled: true
+        service:
+          labels:
+            servicemonitor.kubeaddons.mesosphere.io/path: "api__v1__metrics__prometheus"
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      resources:
+        limits:
+          memory: 750Mi
+        requests:
+          # values extracted from a 1 output/1 input setup here:
+          # https://github.com/fluent/fluent-bit-kubernetes-logging/blob/master/fluent-bit-daemonset-kafka-rest.yml
+          # we double it for 1 output (es)/2 input (tail, systemd) as an approximation
+          cpu: 200m
+          memory: 200Mi
+      parsers:
+        enabled: true
+        json:
+          - name: kubernetes-audit
+            timeKey: requestReceivedTimestamp
+            timeKeep: On
+            timeFormat: "%Y-%m-%dT%H:%M:%S.%L"

--- a/addons/fluentbit/1.5.x/fluentbit-1.yaml
+++ b/addons/fluentbit/1.5.x/fluentbit-1.yaml
@@ -7,9 +7,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: fluentbit
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.7-1"
-    appversion.kubeaddons.mesosphere.io/fluentbit: "1.3.7"
-    values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/helm/charts/d407562/stable/fluent-bit/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.1-1"
+    appversion.kubeaddons.mesosphere.io/fluentbit: "1.5.1"
+    values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/fluent/helm-charts/6cba78c/charts/fluent-bit/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -30,55 +30,140 @@ spec:
     - name: none
       enabled: true
   chartReference:
-    chart: stable/fluent-bit
-    version: 2.8.17
+    chart: fluent-bit
+    repo: https://fluent.github.io/helm-charts
+    version: 0.6.0
     values: |
-      audit:
-        enable: true
-        input:
-          memBufLimit: 35MB
-          parser: kubernetes-audit
-          path: /var/log/kubernetes/audit/*.log
-          bufferChunkSize: 5MB
-          bufferMaxSize: 20MB
-          skipLongLines: Off
-          key: kubernetes-audit
-      backend:
-        es:
-          host: elasticsearch-kubeaddons-client
-          time_key: '@ts'
-        type: es
-      filter:
-        mergeJSONLog: false
-      input:
-        tail:
-          parser: cri
-        systemd:
-          enabled: true
-          filters:
-            systemdUnit: []
-          stripUnderscores: true
-      metrics:
-        enabled: true
-        service:
-          labels:
-            servicemonitor.kubeaddons.mesosphere.io/path: "api__v1__metrics__prometheus"
+      image:
+        tag: 1.5.1
+      service:
+        annotations:
+          prometheus.io/path: "/api/v1/metrics/prometheus"
+          prometheus.io/port: "2020"
+          prometheus.io/scrape: "true"
       tolerations:
-        - effect: NoSchedule
-          operator: Exists
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
+      - operator: Exists
+        key: CriticalAddonsOnly
       resources:
         limits:
           memory: 750Mi
         requests:
-          # values extracted from a 1 output/1 input setup here:
-          # https://github.com/fluent/fluent-bit-kubernetes-logging/blob/master/fluent-bit-daemonset-kafka-rest.yml
-          # we double it for 1 output (es)/2 input (tail, systemd) as an approximation
-          cpu: 200m
-          memory: 200Mi
-      parsers:
-        enabled: true
-        json:
-          - name: kubernetes-audit
-            timeKey: requestReceivedTimestamp
-            timeKeep: On
-            timeFormat: "%Y-%m-%dT%H:%M:%S.%L"
+          cpu: 350m
+          memory: 350Mi
+      podSecurityPolicy:
+        create: true
+      podSecurityContext:
+        fsGroup: 2000
+      securityContext:
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 1000
+      priorityClassName: system-node-critical
+      extraVolumes:
+      - name: tail-db
+        emptyDir: {}
+      extraVolumeMounts:
+      - name: tail-db
+        mountPath: /tail-db
+      config:
+        ## https://docs.fluentbit.io/manual/service
+        service: |
+          [SERVICE]
+              Flush 1
+              Daemon Off
+              Log_Level error
+              Parsers_File parsers.conf
+              Parsers_File custom_parsers.conf
+              HTTP_Server On
+              HTTP_Listen 0.0.0.0
+              HTTP_Port 2020
+
+        ## https://docs.fluentbit.io/manual/pipeline/inputs
+        inputs: |
+          [INPUT]
+              Name tail
+              Path /var/log/kubernetes/audit/*.log
+              Parser kubernetes-audit
+              DB /tail-db/audit.db
+              Tag audit.*
+              Refresh_Interval 5
+              Mem_Buf_Limit 135MB
+              Buffer_Chunk_Size 5MB
+              Buffer_Max_Size 20MB
+              Skip_Long_Lines Off
+              Key kubernetes-audit
+          [INPUT]
+              Name tail
+              Path /var/log/containers/*.log
+              Parser cri
+              DB /tail-db/kube.db
+              Tag kube.*
+              Refresh_Interval 5
+              Mem_Buf_Limit 5MB
+              Skip_Long_Lines On
+          [INPUT]
+              Name systemd
+              Tag host.*
+              Max_Entries 1000
+              Read_From_Tail On
+              Strip_Underscores On
+
+        ## https://docs.fluentbit.io/manual/pipeline/filters
+        filters: |
+          [FILTER]
+              Name kubernetes
+              Match kube.*
+              Merge_Log On
+              Merge_Log_Key log_processed
+              Keep_Log Off
+              K8S-Logging.Parser On
+              K8S-Logging.Exclude On
+
+        ## https://docs.fluentbit.io/manual/pipeline/outputs
+        outputs: |
+          [OUTPUT]
+              Name es
+              Match audit.*
+              Host elasticsearch-kubeaddons-client.kubeaddons.svc.cluster.local.
+              Port 9200
+              Time_Key @ts
+              Logstash_Format On
+              Logstash_Prefix kubernetes_audit
+              Retry_Limit False
+              Buffer_Size 512KB
+          [OUTPUT]
+              Name es
+              Match kube.*
+              Host elasticsearch-kubeaddons-client.kubeaddons.svc.cluster.local.
+              Port 9200
+              Time_Key @ts
+              Logstash_Format On
+              Logstash_Prefix kubernetes_cluster
+              Retry_Limit False
+              Buffer_Size 512KB
+          [OUTPUT]
+              Name es
+              Match host.*
+              Host elasticsearch-kubeaddons-client.kubeaddons.svc.cluster.local.
+              Port 9200
+              Time_Key @ts
+              Logstash_Format On
+              Logstash_Prefix kubernetes_host
+              Retry_Limit False
+              Buffer_Size 512KB
+
+        ## https://docs.fluentbit.io/manual/pipeline/parsers
+        customParsers: |
+          [PARSER]
+              Name kubernetes-audit
+              Format json
+              Time_Keep On
+              Time_Key requestReceivedTimestamp
+              Time_Format %Y-%m-%dT%H:%M:%S.%L


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
- enable audit logs by default
- three inputs and three outputs, one for each, and each in own elasticsearch index
- tolerations for all possible nodes, we want all the logs by default
- podSecurityPolicy creation
- podSecurityContext set
- securityContext set, run unpriviledged and read-only
- set a higher Buffer_Size for elasticsearch responses
- defined FQDN for elasticsearch host
- priorityClassName set
- emptyDir volume for tail-db created on each host

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
```
jql=key in (D2IQ-69770)
```

[D2IQ-69770]

[D2IQ-69770]: https://jira.d2iq.com/browse/D2IQ-69770

**Special notes for your reviewer**:
Closes #369

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fluent-bit: 
- Version 1.5.1 of fluent-bit used
- Three different elasticsearch indicies created
  - kubernetes_cluster-* (for container logs)
  - kubernetes_audit-* (for audit logs from kube-apiserver)
  - kubernetes_host-* (for all systemd host logs)
- Pods no longer run priviledged
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.