### PR TITLE
chore: test changes to wait for pods and containers

### DIFF
--- a/test/addons_test.go
+++ b/test/addons_test.go
@@ -801,6 +801,42 @@ configInline:
     addresses:
     - "172.17.1.200-172.17.1.250"
 `,
+	"elasticsearch": `
+---
+# Reduce resource limits so elasticsearch will deploy on a kind cluster with limited memory.
+client:
+  replicas: 1
+  heapSize: 256m
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+    requests:
+      cpu: 500m
+      memory: 256Mi
+master:
+  replicas: 2
+  heapSize: 256m
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+data:
+  replicas: 1
+  persistence:
+    size: 4Gi
+  heapSize: 1024m
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1536Mi
+    requests:
+      cpu: 100m
+      memory: 1024Mi
+`,
 	"prometheus": `
 ---
 # Remove dependency on persistent volumes and Konvoy's "etcd-certs" secret.

--- a/test/elasticsearch_test.go
+++ b/test/elasticsearch_test.go
@@ -24,7 +24,6 @@ const (
 
 func elasticsearchChecker(t *testing.T, cluster testcluster.Cluster) testharness.Job {
 	return func(t *testing.T) error {
-		time.Sleep(time.Second * 120)
 		localport, stop, err := portForwardPodWithPrefix(cluster, "kubeaddons", esClientPodPrefix, esClientPort)
 		if err != nil {
 			return fmt.Errorf("could not forward port to elasticsearch client pod: %s", err)
@@ -45,7 +44,6 @@ func elasticsearchChecker(t *testing.T, cluster testcluster.Cluster) testharness
 
 func kibanaChecker(t *testing.T, cluster testcluster.Cluster) testharness.Job {
 	return func(t *testing.T) error {
-		time.Sleep(time.Second * 120)
 		localport, stop, err := portForwardPodWithPrefix(cluster, "kubeaddons", kibanaPodPrefix, kibanaPort)
 		if err != nil {
 			return fmt.Errorf("could not forward port to kibana pod: %s", err)

--- a/test/prometheus_test.go
+++ b/test/prometheus_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
-	"time"
 
 	testcluster "github.com/mesosphere/ksphere-testing-framework/pkg/cluster"
 	testharness "github.com/mesosphere/ksphere-testing-framework/pkg/harness"
@@ -25,8 +24,6 @@ const (
 
 func promChecker(t *testing.T, cluster testcluster.Cluster) testharness.Job {
 	return func(t *testing.T) error {
-		time.Sleep(time.Minute * 5)
-		t.Logf("INFO: starting to test prometheus")
 		localport, stop, err := portForwardPodWithPrefix(cluster, "kubeaddons", promPodPrefix, promPort)
 		if err != nil {
 			return fmt.Errorf("could not forward port to prometheus pod: %w", err)

--- a/test/scripts/setup-konvoy.sh
+++ b/test/scripts/setup-konvoy.sh
@@ -10,4 +10,6 @@ fi
 
 set -euo pipefail
 
-curl --silent https://downloads.mesosphere.io/konvoy/konvoy_${KONVOY_VERSION}_${UNAME}.tar.bz2 | tar xjv --strip=1 konvoy_${KONVOY_VERSION}/konvoy
+if [[ ! -f konvoy ]] || [[ "$(./konvoy --version | awk '/Version/ {gsub("\"","",$2); gsub(",","",$2); print $2}')" == "${KONVOY_VERSION}" ]]; then
+  curl --silent https://downloads.mesosphere.io/konvoy/konvoy_${KONVOY_VERSION}_${UNAME}.tar.bz2 | tar xjv --strip=1 konvoy_${KONVOY_VERSION}/konvoy
+fi

--- a/test/util.go
+++ b/test/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	testcluster "github.com/mesosphere/ksphere-testing-framework/pkg/cluster"
 	networkutils "github.com/mesosphere/ksphere-testing-framework/pkg/utils/networking"
@@ -12,13 +13,45 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// podReadyTimeout defines the maximum time to wait within portForwardPodWithPrefix for a pod and its containers
+	// to be Running and Ready. If we hit the timeout, there are most likely issues with the addon itself.
+	podReadyTimeout = 300 * time.Second
+)
+
 func portForwardPodWithPrefix(cluster testcluster.Cluster, ns, prefix, port string) (int, chan struct{}, error) {
 	pod, err := findPodWithPrefix(cluster, ns, prefix)
 	if err != nil {
 		return 0, nil, fmt.Errorf("could not find pod with prefix %s: %s", prefix, err)
 	}
-	if pod.Status.Phase != corev1.PodRunning {
-		return 0, nil, fmt.Errorf("pod %s is not running, it's in phase %s", pod.Name, pod.Status.Phase)
+
+	// Wait for Pod running and its containers to be ready for some time or timeout!
+	timeout := time.After(podReadyTimeout)
+	tick := time.Tick(500 * time.Millisecond)
+	var containersReady bool
+	for {
+		select {
+		case <-timeout:
+			return 0, nil, fmt.Errorf("Timeout after %.0f minutes - Pod %s in phase %s, containers of it are overall not ready", podReadyTimeout.Minutes(), pod.Name, pod.Status.Phase)
+		case <-tick:
+			// Check first that Pod is in Running phase
+			if pod.Status.Phase != corev1.PodRunning {
+				continue
+			}
+			// Check second that containers are in READY phase
+			for _, c := range pod.Status.ContainerStatuses {
+				if !c.Ready && containersReady {
+					containersReady = false
+				} else {
+					containersReady = true
+				}
+			}
+			if !containersReady {
+				continue
+			}
+			break
+		}
+		break
 	}
 	return networkutils.PortForward(cluster.Config(), pod.Namespace, pod.Name, port)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore / Test fixing

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
- added loop with timeout to wait for pods and containers
- updated scripts to only download konvoy if not present and version in test dir not matching (intersting for 
local ;))
- removed sleeps from _test.go files
- lowered elasticsearch addon yaml replicas to minimum

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
```
jql=key in (D2IQ-70677)
```

[D2IQ-70677]

[D2IQ-70677]: https://jira.d2iq.com/browse/D2IQ-70677


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.