### PR TITLE
[elasticsearch] data replica bump (#327)

### DIFF
--- a/addons/elasticsearch/6.8.x/elasticsearch-5.yaml
+++ b/addons/elasticsearch/6.8.x/elasticsearch-5.yaml
@@ -54,6 +54,7 @@ spec:
             cpu: 500m
             memory: 1536Mi
       data:
+        replicas: 4
         updateStrategy:
           type: RollingUpdate
         hooks:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This allows us to bump the number of data nodes to 4 for better long term stability of the elastic search cluster over the period of time indicated by curator. This is a better and much needed suggested amount of data nodes than the usual 2 we have had on POCs. 

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-66837

**Special notes for your reviewer**:
Backport of #327 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Elasticsearch default data nodes has been increased to 4 by default. 
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
