### PR TITLE
Add meaningful aliases to fluent-bit plugins

### DIFF
--- a/addons/fluentbit/1.5.x/fluentbit-5.yaml
+++ b/addons/fluentbit/1.5.x/fluentbit-5.yaml
@@ -110,6 +110,7 @@ spec:
         inputs: |
           [INPUT]
               Name tail
+              Alias kubernetes_audit
               Path /var/log/kubernetes/audit/*.log
               Parser kubernetes-audit
               DB /tail-db/audit.db
@@ -122,6 +123,7 @@ spec:
               Skip_Long_Lines Off
           [INPUT]
               Name tail
+              Alias kubernetes_cluster
               Path /var/log/containers/*.log
               Parser cri
               DB /tail-db/kube.db
@@ -132,6 +134,7 @@ spec:
               Skip_Long_Lines On
           [INPUT]
               Name systemd
+              Alias kubernetes_host
               DB /tail-db/journal.db
               Tag host.*
               Max_Entries 1000
@@ -139,6 +142,7 @@ spec:
               Strip_Underscores On
           [INPUT]
               Name kmsg
+              Alias kubernetes_host_kernel
               Tag kernel
 
         ## https://docs.fluentbit.io/manual/pipeline/filters
@@ -164,6 +168,7 @@ spec:
         outputs: |
           [OUTPUT]
               Name es
+              Alias kubernetes_audit
               Match audit.*
               Host elasticsearch-kubeaddons-client.kubeaddons.svc.cluster.local.
               Port 9200
@@ -174,6 +179,7 @@ spec:
               Buffer_Size 512KB
           [OUTPUT]
               Name es
+              Alias kubernetes_cluster
               Match kube.*
               Host elasticsearch-kubeaddons-client.kubeaddons.svc.cluster.local.
               Port 9200
@@ -184,6 +190,7 @@ spec:
               Buffer_Size 512KB
           [OUTPUT]
               Name es
+              Alias kubernetes_host
               Match host.*
               Host elasticsearch-kubeaddons-client.kubeaddons.svc.cluster.local.
               Port 9200
@@ -194,6 +201,7 @@ spec:
               Buffer_Size 512KB
           [OUTPUT]
               Name es
+              Alias kubernetes_host_kernel
               Match kernel
               Host elasticsearch-kubeaddons-client.kubeaddons.svc.cluster.local.
               Port 9200

--- a/addons/fluentbit/1.5.x/fluentbit-5.yaml
+++ b/addons/fluentbit/1.5.x/fluentbit-5.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: fluentbit
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.2-4"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.2-5"
     appversion.kubeaddons.mesosphere.io/fluentbit: "1.5.2"
     values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/fluent/helm-charts/6cba78c/charts/fluent-bit/values.yaml"
 spec:

--- a/addons/fluentbit/1.5.x/fluentbit-5.yaml
+++ b/addons/fluentbit/1.5.x/fluentbit-5.yaml
@@ -1,0 +1,213 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: fluentbit
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: fluentbit
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.2-4"
+    appversion.kubeaddons.mesosphere.io/fluentbit: "1.5.2"
+    values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/fluent/helm-charts/6cba78c/charts/fluent-bit/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  requires:
+    # This allows us to have fluentbit wait until ES is deployed and has the right configurations up, in particular
+    # setting up index templates
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: elasticsearch
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: true
+  chartReference:
+    chart: fluent-bit
+    repo: https://fluent.github.io/helm-charts
+    version: 0.6.2
+    values: |
+      service:
+        labels:
+          servicemonitor.kubeaddons.mesosphere.io/path: "api__v1__metrics__prometheus"
+          servicemonitor.kubeaddons.mesosphere.io/port: "http"
+          servicemonitor.kubeaddons.mesosphere.io/interval: "10s"
+      serviceMonitor:
+          # right now disabled, as we need another solution for proper dependency to prometheus-operator
+          enabled: false
+          interval: 10s
+          scrapeTimeout: 10s
+          selector:
+            release: prometheus-kubeaddons
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
+      - operator: Exists
+        key: CriticalAddonsOnly
+      resources:
+        limits:
+          memory: 750Mi
+        requests:
+          cpu: 350m
+          memory: 350Mi
+      priorityClassName: system-node-critical
+      securityContext:
+        privileged: true
+      env:
+      - name: FLUENT_BIT_NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      extraVolumes:
+      - name: tail-db
+        emptyDir: {}
+      # we create this to get rid of error messages that would appear on non control-plane nodes
+      - name: kubernetes-audit
+        hostPath:
+          path: /var/log/kubernetes/audit
+          type: DirectoryOrCreate
+      # needed for kmsg input plugin
+      - name: uptime
+        hostPath:
+          path: /proc/uptime
+          type: File
+      - name: kmsg
+        hostPath:
+          path: /dev/kmsg
+          type: CharDevice
+      extraVolumeMounts:
+      - name: tail-db
+        mountPath: /tail-db
+      - name: kubernetes-audit
+        mountPath: /var/log/kubernetes/audit
+      - name: uptime
+        mountPath: /proc/uptime
+      - name: kmsg
+        mountPath: /dev/kmsg
+      config:
+        ## https://docs.fluentbit.io/manual/service
+        service: |
+          [SERVICE]
+              Flush 1
+              Daemon Off
+              Log_Level error
+              Parsers_File parsers.conf
+              Parsers_File custom_parsers.conf
+              HTTP_Server On
+              HTTP_Listen 0.0.0.0
+              HTTP_Port 2020
+
+        ## https://docs.fluentbit.io/manual/pipeline/inputs
+        inputs: |
+          [INPUT]
+              Name tail
+              Path /var/log/kubernetes/audit/*.log
+              Parser kubernetes-audit
+              DB /tail-db/audit.db
+              Tag audit.*
+              Refresh_Interval 10
+              Rotate_Wait 5
+              Mem_Buf_Limit 135MB
+              Buffer_Chunk_Size 5MB
+              Buffer_Max_Size 20MB
+              Skip_Long_Lines Off
+          [INPUT]
+              Name tail
+              Path /var/log/containers/*.log
+              Parser cri
+              DB /tail-db/kube.db
+              Tag kube.*
+              Refresh_Interval 60
+              Rotate_Wait 5
+              Mem_Buf_Limit 5MB
+              Skip_Long_Lines On
+          [INPUT]
+              Name systemd
+              DB /tail-db/journal.db
+              Tag host.*
+              Max_Entries 1000
+              Read_From_Tail On
+              Strip_Underscores On
+          [INPUT]
+              Name kmsg
+              Tag kernel
+
+        ## https://docs.fluentbit.io/manual/pipeline/filters
+        filters: |
+          [FILTER]
+              Name record_modifier
+              Match audit.*
+              Record host ${FLUENT_BIT_NODE_NAME}
+          [FILTER]
+              Name kubernetes
+              Match kube.*
+              Merge_Log On
+              Merge_Log_Key log_processed
+              Keep_Log Off
+              K8S-Logging.Parser On
+              K8S-Logging.Exclude On
+          [FILTER]
+              Name record_modifier
+              Match kernel
+              Record host ${FLUENT_BIT_NODE_NAME}
+
+        ## https://docs.fluentbit.io/manual/pipeline/outputs
+        outputs: |
+          [OUTPUT]
+              Name es
+              Match audit.*
+              Host elasticsearch-kubeaddons-client.kubeaddons.svc.cluster.local.
+              Port 9200
+              Time_Key @ts
+              Logstash_Format On
+              Logstash_Prefix kubernetes_audit
+              Retry_Limit False
+              Buffer_Size 512KB
+          [OUTPUT]
+              Name es
+              Match kube.*
+              Host elasticsearch-kubeaddons-client.kubeaddons.svc.cluster.local.
+              Port 9200
+              Time_Key @ts
+              Logstash_Format On
+              Logstash_Prefix kubernetes_cluster
+              Retry_Limit False
+              Buffer_Size 512KB
+          [OUTPUT]
+              Name es
+              Match host.*
+              Host elasticsearch-kubeaddons-client.kubeaddons.svc.cluster.local.
+              Port 9200
+              Time_Key @ts
+              Logstash_Format On
+              Logstash_Prefix kubernetes_host
+              Retry_Limit False
+              Buffer_Size 512KB
+          [OUTPUT]
+              Name es
+              Match kernel
+              Host elasticsearch-kubeaddons-client.kubeaddons.svc.cluster.local.
+              Port 9200
+              Time_Key @ts
+              Logstash_Format On
+              Logstash_Prefix kubernetes_host_kernel
+              Retry_Limit False
+              Buffer_Size 512KB
+
+        ## https://docs.fluentbit.io/manual/pipeline/parsers
+        customParsers: |
+          [PARSER]
+              Name kubernetes-audit
+              Format json
+              Time_Keep On
+              Time_Key requestReceivedTimestamp
+              Time_Format %Y-%m-%dT%H:%M:%S.%L


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This adds aliases to fluent-bit input and output plugins that match the names of the ES indices where their logs will be stored. This makes fluent-bit's Grafana dashboard more readable, by replacing autogenerated plugin names (e.g. `tail.0`) with the chosen aliases (e.g. `kubernetes_audit`).

Before:

<img width="1210" alt="Screen Shot 2020-08-10 at 1 21 24 PM" src="https://user-images.githubusercontent.com/42242/89827426-6e02f700-db0c-11ea-9511-c3659f61df16.png">

After (note the graph legends):

<img width="1210" alt="Screen Shot 2020-08-10 at 1 16 55 PM" src="https://user-images.githubusercontent.com/42242/89827220-46139380-db0c-11ea-915f-4699f20a0873.png">


**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
\[fluent-bit\] Apply meaningful aliases to plugins and their metrics.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
