### PR TITLE
D2IQ-70889 [dka] bump chart 1.2.6

### DIFF
--- a/addons/dex-k8s-authenticator/1.2.x/dex-k8s-authenticator-4.yaml
+++ b/addons/dex-k8s-authenticator/1.2.x/dex-k8s-authenticator-4.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: dex-k8s-authenticator
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: dex-k8s-authenticator
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.2-1"
+    appversion.kubeaddons.mesosphere.io/dex-k8s-authenticator: "v1.2.2"
+    values.chart.helm.kubeaddons.mesosphere.io/dex-k8s-authenticator: "https://raw.githubusercontent.com/mesosphere/charts/f44c645c6bc843b254bb0f4f97d516f2cfee4707/staging/dex-k8s-authenticator/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.6
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: azure
+      enabled: true
+    - name: gcp
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: dex
+    - matchLabels:
+        kubeaddons.mesosphere.io/provides: ingresscontroller
+  chartReference:
+    chart: dex-k8s-authenticator
+    repo: https://mesosphere.github.io/charts/staging
+    version: 1.2.5
+    values: |
+      ---
+      image:
+        repository: mesosphere/dex-k8s-authenticator
+        tag: v1.2.2-d2iq
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.class: traefik
+        path: /token
+        hosts:
+          - ""
+      dexK8sAuthenticator:
+        #logoUrl: http://<path-to-your-logo.png>
+        #tlsCert: /path/to/dex-client.crt
+        #tlsKey: /path/to/dex-client.key
+        pluginVersion: "v0.1.3"
+        useClusterHostnameForClusterName: true
+        clusters:
+        - name: kubernetes-cluster
+          short_description: "Kubernetes cluster"
+          description: "Kubernetes cluster authenticator"
+          # client_secret: value is generated automatically via initContainers
+          client_id: kube-apiserver
+          issuer: https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex
+          # This URI is just a placeholder and it will be replaced during initContainers
+          # with a URL pointing to the traefik ingress public load balancer.
+          redirect_uri: https://dex-k8s-authenticator-kubeaddons.kubeaddons.svc.cluster.local:5555/token/callback/kubernetes-cluster
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      deploymentAnnotations:
+        # The certificate can change because it was rotated or different cluster
+        # DNS name has been set.
+        secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate"
+        configmap.reloader.stakater.com/reload: "dex-k8s-authenticator-kubeaddons"
+      initContainers:
+      - name: initialize-dka-config
+        image: mesosphere/kubeaddons-addon-initializer:v0.2.11
+        args: ["dexK8sAuthenticator"]
+        env:
+        - name: "DKA_CONFIGMAP_NAME"
+          value: "dex-k8s-authenticator-kubeaddons"
+        - name: "DKA_NAMESPACE"
+          value: "kubeaddons"
+        - name: "DKA_INGRESS_NAMESPACE"
+          value: "kubeaddons"
+        - name: "DKA_INGRESS_SERVICE_NAME"
+          value: "traefik-kubeaddons"
+        - name: "DKA_WEB_PREFIX_PATH"
+          value: "/token"

--- a/addons/dex-k8s-authenticator/1.2.x/dex-k8s-authenticator-4.yaml
+++ b/addons/dex-k8s-authenticator/1.2.x/dex-k8s-authenticator-4.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dex-k8s-authenticator
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.2-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.2-4"
     appversion.kubeaddons.mesosphere.io/dex-k8s-authenticator: "v1.2.2"
     values.chart.helm.kubeaddons.mesosphere.io/dex-k8s-authenticator: "https://raw.githubusercontent.com/mesosphere/charts/f44c645c6bc843b254bb0f4f97d516f2cfee4707/staging/dex-k8s-authenticator/values.yaml"
 spec:

--- a/addons/dex-k8s-authenticator/1.2.x/dex-k8s-authenticator-4.yaml
+++ b/addons/dex-k8s-authenticator/1.2.x/dex-k8s-authenticator-4.yaml
@@ -32,7 +32,7 @@ spec:
   chartReference:
     chart: dex-k8s-authenticator
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.2.5
+    version: 1.2.6
     values: |
       ---
       image:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Bumps dka chart to 1.2.6. This chart contains a bugfix for the windows instruction page.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
https://jira.d2iq.com/browse/D2IQ-70889

**Special notes for your reviewer**:
https://github.com/mesosphere/kubernetes-base-addons/commit/ed2337400e47260e130d08e19070d29171fd2534

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[dex-k8s-authenticator] Fixed bug causing `certificate-authority=`  option to be added to token instructions on the windows tab when it should have been omitted. 
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [x] The documentation is updated where needed.
