### PR TITLE
[chore] disable istio to fix CI

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce
 	github.com/google/uuid v1.1.1
-	github.com/mesosphere/ksphere-testing-framework v0.0.0-20200806132303-8e10596082d3
+	github.com/mesosphere/ksphere-testing-framework v0.0.0-20200814171113-1a98809a8734
 	github.com/mesosphere/kubeaddons v0.18.2
 	go.uber.org/atomic v1.5.1 // indirect
 	go.uber.org/multierr v1.4.0 // indirect

--- a/test/groups.yaml
+++ b/test/groups.yaml
@@ -76,13 +76,14 @@ prometheus:
 #
 # All Istio related addons should be tested as a part of this group
 # ------------------------------------------------------------------------------
-istio:
-    - "prometheus"
-    - "metallb"
-    - "opsportal"
-    - "cert-manager"
-    - "istio"
-    - "flagger"
+#istio:
+#    - "prometheus"
+#    - "prometheusadapter"
+#    - "metallb"
+#    - "opsportal"
+#    - "cert-manager"
+#    - "istio"
+#    - "flagger"
 
 # ------------------------------------------------------------------------------
 # Local Volume Provisioner
@@ -131,3 +132,5 @@ disabled:
     # TODO: Konvoy doesn't fully support GCP just yet
     - "gcpdisk-csi-driver"
     - "gcpdiskprovisioner"
+    # TODO: Istio is in preview and not yet supported, at the time of writing several deployment issues which we're not ready to tackle yet.
+    - "istio"


### PR DESCRIPTION
Disables Istio for now to reduce KBA failures do to other addons in the group getting updated.
Follow up in [D2IQ-71071](https://jira.d2iq.com/browse/D2IQ-71071)