### PR TITLE
Automated chart bump elasticsearch-exporter-3.7.0

### DIFF
--- a/addons/elasticsearchexporter/1.1.x/elasticsearchexporter-1.yaml
+++ b/addons/elasticsearchexporter/1.1.x/elasticsearchexporter-1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: Addon
 metadata:
@@ -7,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: elasticsearchexporter
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-2"
     appversion.kubeaddons.mesosphere.io/elasticsearchexporter: "1.1.0"
-    values.chart.helm.kubeaddons.mesosphere.io/elasticsearchexporter: "https://raw.githubusercontent.com/helm/charts/08fc376647d43169743dcf04f1e88a2aec9e5f3d/stable/elasticsearch-exporter/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/elasticsearchexporter: "https://raw.githubusercontent.com/helm/charts/506eedd/stable/elasticsearch-exporter/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -29,7 +28,7 @@ spec:
         kubeaddons.mesosphere.io/name: elasticsearch
   chartReference:
     chart: stable/elasticsearch-exporter
-    version: 2.1.1
+    version: 3.7.0
     values: |
       ---
       es:


### PR DESCRIPTION
```release-note
Updated elasticsearch-exporter from 2.11 to 3.7.0

* Add a parameter for the elasticsearch-exporter: es.indices_settings as it is supported since version 1.0.4 (the elasticsearch-exporter chart is supporting the version 1.1.0)
* Update description for envFromSecret parameter in readme
* Feature flap the flag es.uri to allow fallback to env var ES_URI
* Allow setting environment variables with k8s secret information to support referencing already existing sensitive parameters.
* Add es.ssl.client.enabled value for better functionality readability
* Add option to disable client cert auth in Elasticsearch exporter
* Add the serviceMonitor targetLabels key as documented in the Prometheus Operator API
* Add log.level and log.format configs
* Add the ServiceMonitor metricRelabelings key as documented in the Prometheus Operator API
* Add sampleLimit configuration option
```