### PR TITLE
Automated chart bump opsportal-0.3.22

### DIFF
--- a/addons/opsportal/1.1.x/opsportal-12.yaml
+++ b/addons/opsportal/1.1.x/opsportal-12.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kubeaddons.mesosphere.io/v1beta2
 kind: Addon
 metadata:
@@ -7,10 +6,10 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: opsportal
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-12"
-    appversion.kubeaddons.mesosphere.io/opsportal: "1.1.0"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.0-1"
+    appversion.kubeaddons.mesosphere.io/opsportal: "1.5.0"
     endpoint.kubeaddons.mesosphere.io/opsportal: /ops/portal/
-    values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/6c5e399d3ac34a9fdf65cc26c577d5ab54c39be3/stable/opsportal/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/1419734/stable/opsportal/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -28,7 +27,7 @@ spec:
   chartReference:
     chart: opsportal
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.3.21
+    version: 0.3.22
     valuesRemap:
       "kommander-ui.ingress.extraAnnotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
     values: |

--- a/addons/opsportal/1.5.x/opsportal-1.yaml
+++ b/addons/opsportal/1.5.x/opsportal-1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kubeaddons.mesosphere.io/v1beta2
 kind: Addon
 metadata:
@@ -7,10 +6,10 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: opsportal
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-12"
-    appversion.kubeaddons.mesosphere.io/opsportal: "1.1.0"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.0-1"
+    appversion.kubeaddons.mesosphere.io/opsportal: "1.5.0"
     endpoint.kubeaddons.mesosphere.io/opsportal: /ops/portal/
-    values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/6c5e399d3ac34a9fdf65cc26c577d5ab54c39be3/stable/opsportal/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/1419734/stable/opsportal/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -28,7 +27,7 @@ spec:
   chartReference:
     chart: opsportal
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.3.21
+    version: 0.3.22
     valuesRemap:
       "kommander-ui.ingress.extraAnnotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
     values: |


### PR DESCRIPTION
There may have been customer-facing changes, but I can't parse them out of the kommander releases.

```release-notes
none
```
