### PR TITLE
[stable-1.x] prometheus: disable controller-manager and scheduler serviceMonitors

### DIFF
--- a/addons/prometheus/0.35.x/prometheus-3.yaml
+++ b/addons/prometheus/0.35.x/prometheus-3.yaml
@@ -10,7 +10,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.35.1-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.35.1-2"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.35.1"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.15.2"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.20.0"
@@ -239,6 +239,10 @@ spec:
             requests:
               cpu: 300m
               memory: 1500Mi
+      kubeControllerManager:
+        enabled: false
+      kubeScheduler:
+        enabled: false              
       alertmanager:
         ingress:
           enabled: true


### PR DESCRIPTION
Signed-off-by: Dimitri Koshkin <dimitri.koshkin@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug, backport of https://github.com/mesosphere/kubernetes-base-addons/pull/474

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-71303)
* https://jira.d2iq.com/browse/D2iQ-71303
-->
https://jira.d2iq.com/browse/D2IQ-71303

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
prometheus: disable ServiceMonitors for kube-controller-manager and kube-scheduler. kubernetes has determined the ports that were used for these tests was insecure and has limited it to localhost only. This causes these specific tests to fail. The state of the controller-manager and scheduler pods are still tracked in general as pods.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
