### PR TITLE
istio: Bump chart to v1.6.7

### DIFF
--- a/addons/istio/1.6.x/istio-6.yaml
+++ b/addons/istio/1.6.x/istio-6.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: ClusterAddon
+metadata:
+  name: istio
+  labels:
+    kubeaddons.mesosphere.io/name: istio
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.4-5"
+    appversion.kubeaddons.mesosphere.io/istio: "1.6.4"
+    appversion.kubeaddons.mesosphere.io/kiali: "1.18.0"
+    appversion.kubeaddons.mesosphere.io/jaeger: "1.16.0"
+    stage.kubeaddons.mesosphere.io/kiali: Preview
+    stage.kubeaddons.mesosphere.io/jaeger: Preview
+    endpoint.kubeaddons.mesosphere.io/kiali: "/ops/portal/kiali"
+    endpoint.kubeaddons.mesosphere.io/jaeger: "/ops/portal/jaeger"
+    docs.kubeaddons.mesosphere.io/istio: "https://istio.io/docs/"
+    docs.kubeaddons.mesosphere.io/kiali: "https://istio.io/docs/tasks/telemetry/kiali/"
+    docs.kubeaddons.mesosphere.io/jaeger: "https://istio.io/docs/tasks/telemetry/distributed-tracing/jaeger/"
+    values.chart.helm.kubeaddons.mesosphere.io/istio: "https://raw.githubusercontent.com/mesosphere/charts/a8106505cb3fb5ed42e41ceadffae9e78bb226a9/staging/istio/values.yaml"
+spec:
+  namespace: istio-system
+  requires:
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: cert-manager
+    - matchLabels:
+        kubeaddons.mesosphere.io/name: prometheus
+  kubernetes:
+    minSupportedVersion: v1.16.0
+  cloudProvider:
+    - name: aws
+      enabled: false
+    - name: azure
+      enabled: false
+    - name: gcp
+      enabled: false
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: false
+  chartReference:
+    chart: istio
+    repo: https://mesosphere.github.io/charts/staging
+    version: 1.6.6
+    values: |
+      istioOperator:
+        hub: docker.io/istio
+        tag: 1.6.4
+
+        addonComponents:
+          kiali:
+            enabled: true
+          tracing:
+            enabled: true
+
+        components:
+          ingressGateways:
+          - enabled: true
+            k8s:
+              hpaSpec:
+                minReplicas: 2
+            name: istio-ingressgateway
+          pilot:
+            k8s:
+              hpaSpec:
+                minReplicas: 2
+
+        values:
+          kiali:
+            contextPath: /ops/portal/kiali
+            dashboard:
+              auth:
+                strategy: anonymous
+              grafanaInClusterURL: http://prometheus-kubeaddons-grafana.kubeaddons:3000
+              jaegerInClusterURL: http://tracing/jaeger
+            prometheusAddr: http://prometheus-kubeaddons-prom-prometheus.kubeaddons:9090
+
+          tracing:
+            contextPath: /ops/portal/jaeger

--- a/addons/istio/1.6.x/istio-6.yaml
+++ b/addons/istio/1.6.x/istio-6.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: istio
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.4-5"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.4-6"
     appversion.kubeaddons.mesosphere.io/istio: "1.6.4"
     appversion.kubeaddons.mesosphere.io/kiali: "1.18.0"
     appversion.kubeaddons.mesosphere.io/jaeger: "1.16.0"
@@ -41,7 +41,7 @@ spec:
   chartReference:
     chart: istio
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.6.6
+    version: 1.6.7
     values: |
       istioOperator:
         hub: docker.io/istio


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Bump chart to v1.6.7 (follow up to https://github.com/mesosphere/charts/pull/767) which removes a service monitor that was causing TargetDown alerts due to pulling in bad targets. We will want to backport this to konvoy 1.5.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
https://jira.d2iq.com/browse/D2IQ-70603

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
istio: The "kubernetes-service-monitor" service monitor has been removed.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
