### PR TITLE
Dispatchfile: fix task name

### DIFF
--- a/Dispatchfile
+++ b/Dispatchfile
@@ -71,6 +71,6 @@ action(tasks=["dispatch-integration-test", clean_kind], on=pull_request(chatops=
 action(tasks=["lint-yaml", clean_kind], on=pull_request())
 action(tasks=["lint-yaml", clean_kind], on=pull_request(chatops=["lint","test"]))
 
-do_bump_charts = bump_charts(repo_name="kubernetes-base-addons", task_name="kba_bump_charts")
-action(name="bump-charts", on=cron(schedule="0 3 1,15 * *"), tasks=[do_bump_charts])
+do_bump_charts = bump_charts(repo_name="kubernetes-base-addons", task_name="kba-bumps")
+action(name="bump-charts", on=cron(schedule="0 3 * * 5"), tasks=[do_bump_charts])
 


### PR DESCRIPTION
The task name can't have underscores. This issue was only caught when the cron job tried to run because of an issue with Dispatch where the pipeline isn't generated immediately if the task is imported from somewhere else. I have opened a ticket to track this problem: https://jira.d2iq.com/browse/D2IQ-71514

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
