### PR TITLE
Automated chart bump cert-manager-setup-0.1.17

### DIFF
--- a/addons/cert-manager/0.10.x/cert-manager-8.yaml
+++ b/addons/cert-manager/0.10.x/cert-manager-8.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: ClusterAddon
 metadata:
@@ -6,10 +5,10 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: cert-manager
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.10.1-8"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.10.1-9"
     appversion.kubeaddons.mesosphere.io/cert-manager: "0.10.1"
     docs.kubeaddons.mesosphere.io/cert-manager: "https://docs.cert-manager.io/en/release-0.10/"
-    values.chart.helm.kubeaddons.mesosphere.io/cert-manager: "https://raw.githubusercontent.com/mesosphere/charts/848f804/staging/cert-manager-setup/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/cert-manager: "https://raw.githubusercontent.com/mesosphere/charts/c36a9b7/staging/cert-manager-setup/values.yaml"
 spec:
   namespace: cert-manager
   kubernetes:
@@ -28,7 +27,7 @@ spec:
   chartReference:
     chart: cert-manager-setup
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.1.16
+    version: 0.1.17
     values: |
       ---
       issuers:


### PR DESCRIPTION
use a fixed version of kubectl
```release-notes
none
```