### PR TITLE
Revert "Automated chart bump elasticsearch-1.32.5"

### DIFF
--- a/addons/elasticsearch/6.8.x/elasticsearch-7.yaml
+++ b/addons/elasticsearch/6.8.x/elasticsearch-7.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: Addon
 metadata:
@@ -9,9 +10,9 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.6-1"
-    appversion.kubeaddons.mesosphere.io/elasticsearch: "6.8.6"
-    values.chart.helm.kubeaddons.mesosphere.io/elasticsearch: "https://raw.githubusercontent.com/helm/charts/76696b9/stable/elasticsearch/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.2-7"
+    appversion.kubeaddons.mesosphere.io/elasticsearch: "6.8.2"
+    values.chart.helm.kubeaddons.mesosphere.io/elasticsearch: "https://raw.githubusercontent.com/helm/charts/6bfbc8018cd4440637b07c7559d5812e4d9db34d/stable/elasticsearch/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
@@ -28,7 +29,7 @@ spec:
       enabled: true
   chartReference:
     chart: stable/elasticsearch
-    version: 1.32.5
+    version: 1.32.0
     values: |
       ---
       client:


### PR DESCRIPTION
Reverts mesosphere/kubernetes-base-addons#497

The chart upgrade fixes no issues we had. It also changes the StatefulSet selectors causing upgrades to fail.