### PR TITLE
Automated chart bump fluent-bit-0.7.1

### DIFF
--- a/addons/fluentbit/fluentbit.yaml
+++ b/addons/fluentbit/fluentbit.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: fluentbit
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.4-1"
-    appversion.kubeaddons.mesosphere.io/fluentbit: "1.5.4"
-    values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/fluent/helm-charts/3c4a3db/charts/fluent-bit/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.6-1"
+    appversion.kubeaddons.mesosphere.io/fluentbit: "1.5.6"
+    values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/fluent/helm-charts/5e20fbc/charts/fluent-bit/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -31,7 +31,7 @@ spec:
   chartReference:
     chart: fluent-bit
     repo: https://fluent.github.io/helm-charts
-    version: 0.6.3
+    version: 0.7.1
     values: |
       service:
         labels:


### PR DESCRIPTION
```release-note
Fluent-bit:
  - bump the fluent-bit app version to 1.5.6
    - aws: utils: fix mem leak in flb_imds_request
    - fix double free when destroying connections if the endpoint in unavailable
    - remove noisy error introduced in v1.5.5
    - fix deletion of pending connections in the destroy_queue
```