### PR TITLE
Automated chart bump istio-1.6.11

### DIFF
--- a/addons/istio/istio.yaml
+++ b/addons/istio/istio.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: ClusterAddon
 metadata:
@@ -6,8 +5,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: istio
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.9-0"
-    appversion.kubeaddons.mesosphere.io/istio: "1.6.9"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.11-1"
+    appversion.kubeaddons.mesosphere.io/istio: "1.6.11"
     appversion.kubeaddons.mesosphere.io/kiali: "1.18.0"
     appversion.kubeaddons.mesosphere.io/jaeger: "1.16.0"
     stage.kubeaddons.mesosphere.io/kiali: Preview
@@ -17,7 +16,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/istio: "https://istio.io/docs/"
     docs.kubeaddons.mesosphere.io/kiali: "https://istio.io/docs/tasks/telemetry/kiali/"
     docs.kubeaddons.mesosphere.io/jaeger: "https://istio.io/docs/tasks/telemetry/distributed-tracing/jaeger/"
-    values.chart.helm.kubeaddons.mesosphere.io/istio: "https://raw.githubusercontent.com/mesosphere/charts/a7d3c02bac8c4c3ae02854e60483b97cfb80b1b7/staging/istio/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/istio: "https://raw.githubusercontent.com/mesosphere/charts/671c591/staging/istio/values.yaml"
 spec:
   namespace: istio-system
   requires:
@@ -41,7 +40,7 @@ spec:
   chartReference:
     chart: istio
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.6.9
+    version: 1.6.11
     values: |
       istioOperator:
         addonComponents:


### PR DESCRIPTION
# Release Notes
```
- Security Fix - CVE-2020-25017: In some cases, Envoy only considers the first value when multiple headers are present. Also, Envoy does not replace all existing occurrences of a non-inline header. CVSS Score: 8.3 AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
```