### PR TITLE
[release/2.5] backport: cert-manager/fluentbit: upgrade-strategy delete (#574)

### DIFF
--- a/addons/cert-manager/cert-manager.yaml
+++ b/addons/cert-manager/cert-manager.yaml
@@ -5,10 +5,11 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: cert-manager
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.10.1-9"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.10.1-10"
     appversion.kubeaddons.mesosphere.io/cert-manager: "0.10.1"
     docs.kubeaddons.mesosphere.io/cert-manager: "https://docs.cert-manager.io/en/release-0.10/"
     values.chart.helm.kubeaddons.mesosphere.io/cert-manager: "https://raw.githubusercontent.com/mesosphere/charts/c36a9b7/staging/cert-manager-setup/values.yaml"
+    helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<0.1.17\", \"strategy\": \"delete\"}]"
 spec:
   namespace: cert-manager
   kubernetes:

--- a/addons/fluentbit/fluentbit.yaml
+++ b/addons/fluentbit/fluentbit.yaml
@@ -6,9 +6,12 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: fluentbit
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.6-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.6-2"
     appversion.kubeaddons.mesosphere.io/fluentbit: "1.5.6"
     values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/fluent/helm-charts/5e20fbc/charts/fluent-bit/values.yaml"
+    # the older versions were being deployed from stable/fluent-bit
+    # and were versioned like 2.8.x
+    helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \">=2.8.0\", \"strategy\": \"delete\"}]"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
The Deployment selectors changed for `fluentbit` and `cert-manager`, need to use the `delete` `upgrade-strategy`.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- cert-manager: The Deployment selectors were changed, use `delete` `upgrade-strategy`.
- fluentbit: The Deployment selectors were changed, use `delete` `upgrade-strategy`.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
