### PR TITLE
Automated chart bump fluent-bit-0.7.3

### DIFF
--- a/addons/fluentbit/fluentbit.yaml
+++ b/addons/fluentbit/fluentbit.yaml
@@ -6,12 +6,13 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: fluentbit
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.6-2"
-    appversion.kubeaddons.mesosphere.io/fluentbit: "1.5.6"
-    values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/fluent/helm-charts/5e20fbc/charts/fluent-bit/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.7-1"
+    appversion.kubeaddons.mesosphere.io/fluentbit: "1.5.7"
+    values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/fluent/helm-charts/8b430b9/charts/fluent-bit/values.yaml"
     # the older versions were being deployed from stable/fluent-bit
     # and were versioned like 2.8.x
-    helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \">=2.8.0\", \"strategy\": \"delete\"}]"
+    helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \">=2.8.0\"\
+      , \"strategy\": \"delete\"}]"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -34,7 +35,7 @@ spec:
   chartReference:
     chart: fluent-bit
     repo: https://fluent.github.io/helm-charts
-    version: 0.7.1
+    version: 0.7.3
     values: |
       service:
         labels:


### PR DESCRIPTION
release-notes
```release-note
- Upgrades fluent-bit to v1.5.7. See https://fluentbit.io/announcements/v1.5.7.
```
