### PR TITLE
fix: fluentbit should not keep retrying indefinitely

### DIFF
--- a/addons/fluentbit/fluentbit.yaml
+++ b/addons/fluentbit/fluentbit.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: fluentbit
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.6-2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.6-3"
     appversion.kubeaddons.mesosphere.io/fluentbit: "1.5.6"
     values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/fluent/helm-charts/5e20fbc/charts/fluent-bit/values.yaml"
     # the older versions were being deployed from stable/fluent-bit

--- a/addons/fluentbit/fluentbit.yaml
+++ b/addons/fluentbit/fluentbit.yaml
@@ -177,7 +177,10 @@ spec:
               Time_Key @ts
               Logstash_Format On
               Logstash_Prefix kubernetes_audit
-              Retry_Limit 10
+              # A small fraction of audit logs will be rejected by Elasticsearch because values may have an inconsistent type.
+              # We set a low retry limit here in order to prevent fluent-bit from backing up while it repeatedly retries flushing these logs.
+              # See https://github.com/uken/fluent-plugin-elasticsearch#random-400---rejected-by-elasticsearch-is-occured-why.
+              Retry_Limit 1
               Buffer_Size 512KB
           [OUTPUT]
               Name es

--- a/addons/fluentbit/fluentbit.yaml
+++ b/addons/fluentbit/fluentbit.yaml
@@ -177,7 +177,7 @@ spec:
               Time_Key @ts
               Logstash_Format On
               Logstash_Prefix kubernetes_audit
-              Retry_Limit False
+              Retry_Limit 10
               Buffer_Size 512KB
           [OUTPUT]
               Name es
@@ -188,7 +188,7 @@ spec:
               Time_Key @ts
               Logstash_Format On
               Logstash_Prefix kubernetes_cluster
-              Retry_Limit False
+              Retry_Limit 10
               Buffer_Size 512KB
           [OUTPUT]
               Name es
@@ -199,7 +199,7 @@ spec:
               Time_Key @ts
               Logstash_Format On
               Logstash_Prefix kubernetes_host
-              Retry_Limit False
+              Retry_Limit 10
               Buffer_Size 512KB
           [OUTPUT]
               Name es
@@ -210,7 +210,7 @@ spec:
               Time_Key @ts
               Logstash_Format On
               Logstash_Prefix kubernetes_host_kernel
-              Retry_Limit False
+              Retry_Limit 10
               Buffer_Size 512KB
 
         ## https://docs.fluentbit.io/manual/pipeline/parsers


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
BUG

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Keep retrying on errors causes us to keep them perpetually in memory and fill out our buffer choking off fluentbit from pushing logs

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix fluentbit configuration to unblock output buffer. 
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
