### PR TITLE
feat: bump for cert-manager-upgrade

### DIFF
--- a/addons/cert-manager/cert-manager.yaml
+++ b/addons/cert-manager/cert-manager.yaml
@@ -31,7 +31,7 @@ spec:
     version: 0.2.4
     values: |
       ---
-      upgradeImage: "mesosphere/kubeaddons-addon-initializer:v3.0.1"
+      upgradeImage: "mesosphere/kubeaddons-addon-initializer:v0.3.1"
       issuers:
         - name: kubernetes-root-issuer
           secretName: kubernetes-root-ca

--- a/addons/cert-manager/cert-manager.yaml
+++ b/addons/cert-manager/cert-manager.yaml
@@ -5,13 +5,11 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: cert-manager
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.1-2"
-    appversion.kubeaddons.mesosphere.io/cert-manager: "1.0.1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.3-1"
+    appversion.kubeaddons.mesosphere.io/cert-manager: "1.0.3"
     docs.kubeaddons.mesosphere.io/cert-manager: "https://cert-manager.io/docs/release-notes/release-notes-1.0/"
     values.chart.helm.kubeaddons.mesosphere.io/cert-manager: "https://raw.githubusercontent.com/mesosphere/charts/c36a9b7/staging/cert-manager-setup/values.yaml"
-    # when upgrading from the older v0.1 version deployment selectors changed making it backwards incompatible for standard upgrades
-    helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<0.1.17\", \"strategy\": \"delete\"}]"
-    helm2.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<0.1.17\", \"strategy\": \"delete\"}]"
+    helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<0.2.0\", \"strategy\": \"delete\"}]"
 spec:
   namespace: cert-manager
   kubernetes:
@@ -29,10 +27,11 @@ spec:
       enabled: true
   chartReference:
     chart: cert-manager-setup
-    repo: https://mesosphere.github.io/charts/staging
-    version: 0.2.3
+    repo: https://mesosphere.github.io/charts/stable
+    version: 0.2.4
     values: |
       ---
+      upgradeImage: "mesosphere/kubeaddons-addon-initializer:v3.0.1"
       issuers:
         - name: kubernetes-root-issuer
           secretName: kubernetes-root-ca

--- a/addons/cert-manager/cert-manager.yaml
+++ b/addons/cert-manager/cert-manager.yaml
@@ -8,7 +8,7 @@ metadata:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.3-1"
     appversion.kubeaddons.mesosphere.io/cert-manager: "1.0.3"
     docs.kubeaddons.mesosphere.io/cert-manager: "https://cert-manager.io/docs/release-notes/release-notes-1.0/"
-    values.chart.helm.kubeaddons.mesosphere.io/cert-manager: "https://raw.githubusercontent.com/mesosphere/charts/c36a9b7/staging/cert-manager-setup/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/cert-manager: "https://raw.githubusercontent.com/mesosphere/charts/885f3af/stable/cert-manager-setup/values.yaml"
     helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<0.2.0\", \"strategy\": \"delete\"}]"
 spec:
   namespace: cert-manager

--- a/test/scripts/test-wrapper.go
+++ b/test/scripts/test-wrapper.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-    "log"
+	"log"
 	"os"
 	"os/exec"
 	"regexp"

--- a/test/scripts/test-wrapper.go
+++ b/test/scripts/test-wrapper.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+    "log"
 	"os"
 	"os/exec"
 	"regexp"
@@ -101,8 +102,10 @@ func getModifiedAddons() ([]addonName, error) {
 }
 
 func ensureModifiedAddonsHaveUpdatedRevisions(namesOfModifiedAddons []addonName, repo repositories.Repository) error {
+    l := log.New(os.Stderr,"",0)
+
 	for _, addonName := range namesOfModifiedAddons {
-		fmt.Printf("INFO: ensuring revision was updated for modified addon %s\n", addonName)
+		l.Printf("INFO: ensuring revision was updated for modified addon %s\n", addonName)
 
 		modifiedAddonRevisions, err := repo.GetAddon(string(addonName))
 		if err != nil {
@@ -117,7 +120,7 @@ func ensureModifiedAddonsHaveUpdatedRevisions(namesOfModifiedAddons []addonName,
 		upstreamAddon, err := testutils.GetLatestAddonRevisionFromLocalRepoBranch("../", upstreamRemote, upstreamBranch, string(addonName))
 		if err != nil {
 			if strings.Contains(err.Error(), "directory not found") {
-				fmt.Printf("%s is a new addon, revision check skipped", addonName)
+				l.Printf("%s is a new addon, revision check skipped", addonName)
 				continue
 			}
 			return err
@@ -130,7 +133,7 @@ func ensureModifiedAddonsHaveUpdatedRevisions(namesOfModifiedAddons []addonName,
 			return fmt.Errorf("the revision for addons %s was not properly updated (current: %s, previous from branch %s: %s). Please update the revision for any addons which you modify (see CONTRIBUTING.md)", addonName, modifiedVersion, upstreamBranch, upstreamVersion)
 		}
 
-		fmt.Printf("INFO: addon %s has an updated revision %s (upstream branch %s: %s)\n", addonName, modifiedVersion, upstreamBranch, upstreamVersion)
+		l.Printf("INFO: addon %s has an updated revision %s (upstream branch %s: %s)\n", addonName, modifiedVersion, upstreamBranch, upstreamVersion)
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Uses latest cert-manager-setup chart which brings cert-manager upgrade support

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
https://jira.d2iq.com/browse/D2IQ-71558

**Special notes for your reviewer**:
chart PR: https://github.com/mesosphere/charts/pull/830/files
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[cert-manager] cert-manager addon now supports being upgraded from v0.10 to v1.0.3. 
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
