### PR TITLE
defaultstorageclass-protection: Bump chart to add servicemonitor labels

### DIFF
--- a/addons/defaultstorageclass-protection/defaultstorageclass-protection.yaml
+++ b/addons/defaultstorageclass-protection/defaultstorageclass-protection.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: defaultstorageclass-protection
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.0.3-1"
-    appversion.kubeaddons.mesosphere.io/defaultstorageclass-protection: "0.0.3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.0.4-1"
+    appversion.kubeaddons.mesosphere.io/defaultstorageclass-protection: "0.0.4"
 spec:
   requires:
     - matchLabels:

--- a/addons/defaultstorageclass-protection/defaultstorageclass-protection.yaml
+++ b/addons/defaultstorageclass-protection/defaultstorageclass-protection.yaml
@@ -28,7 +28,7 @@ spec:
   chartReference:
     chart: defaultstorageclass
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.0.3
+    version: 0.0.4
     values: |
       ---
       issuer:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Follow-up to https://github.com/mesosphere/charts/pull/851 - bump chart to pull in servicemonitor labels. Will include necessary prom config changes in another PR to scrape dstorageclass metrics.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
https://jira.d2iq.com/browse/D2IQ-72691

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: Add servicemonitor labels to enable metrics collection
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
