### PR TITLE
prometheus: Add servicemonitor for defaultstorageclass

### DIFF
--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -10,7 +10,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.38.1-18"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.38.1-19"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.38.1"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.19.2"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.20.0"
@@ -138,6 +138,24 @@ spec:
               - path: /_prometheus/metrics
                 targetPort: 5601
                 interval: 30s
+          - name: kubeaddons-service-monitor-metrics-defaultstorageclass
+            selector:
+              matchLabels:
+                servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
+                kubeaddons.mesosphere.io/name: "defaultstorageclass"
+            namespaceSelector:
+              matchNames:
+                - kubeaddons
+            endpoints:
+              - port: https
+                interval: 30s
+                scheme: https
+                bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+                tlsConfig:
+                  caFile: "/etc/prometheus/secrets/dstorageclass-webhook-server-cert/ca.crt"
+                  certFile: "/etc/prometheus/secrets/dstorageclass-webhook-server-cert/tls.crt"
+                  keyFile: "/etc/prometheus/secrets/dstorageclass-webhook-server-cert/tls.key"
+                  insecureSkipVerify: true
           - name: kubeaddons-service-monitor-metrics-dex-controller
             selector:
               matchLabels:
@@ -265,6 +283,7 @@ spec:
           secrets:
             - etcd-certs
             - dex
+            - dstorageclass-webhook-server-cert
           externalUrl: "/ops/portal/prometheus"
           storageSpec:
             volumeClaimTemplate:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Adds service monitor to scrape defaultstorageclass metrics (https://github.com/mesosphere/kubernetes-base-addons/pull/619)

![image](https://user-images.githubusercontent.com/5897740/97063931-78535f80-1557-11eb-9ae9-ab433d018d17.png)


**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
https://jira.d2iq.com/browse/D2IQ-72691

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
prometheus: Scrape defaultstorageclass metrics
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
