### PR TITLE
Bump dex-2.8.9 to fix dex-controller metrics collection

### DIFF
--- a/addons/dex/dex.yaml
+++ b/addons/dex/dex.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: Addon
 metadata:
@@ -7,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dex
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "2.22.0-9"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "2.22.0-10"
     appversion.kubeaddons.mesosphere.io/dex: "2.22.0"
-    values.chart.helm.kubeaddons.mesosphere.io/dex: "https://raw.githubusercontent.com/mesosphere/charts/1691f6b7f7faa5842a2a30d684839a68819d8682/stable/dex/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/dex: "https://raw.githubusercontent.com/mesosphere/charts/2ae9cef/stable/dex/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -30,7 +29,7 @@ spec:
   chartReference:
     chart: dex
     repo: https://mesosphere.github.io/charts/stable
-    version: 2.8.8
+    version: 2.8.9
     values: |
       ---
       # Temporarily we're going to use our custom built container. Documentation


### PR DESCRIPTION
Add release note or "none":
```release-note
dex: Fix to enable dex-controller metrics collection
```