### PR TITLE
Add Prometheus service monitor for flagger-loadtester

### DIFF
--- a/addons/flagger/flagger.yaml
+++ b/addons/flagger/flagger.yaml
@@ -8,9 +8,9 @@ metadata:
   annotations:
     sidecar.istio.io/inject: "false"
     appversion.kubeaddons.mesosphere.io/flagger: "0.19.0"
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.19.0-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.19.0-2"
     docs.kubeaddons.mesosphere.io/flagger: "https://docs.flagger.app/"
-    values.chart.helm.kubeaddons.mesosphere.io/flagger: "https://raw.githubusercontent.com/weaveworks/flagger/c6f3a87/charts/flagger/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/flagger: "https://raw.githubusercontent.com/mesosphere/charts/f4105ebb01fc758a4af356069a8ceae043201057/staging/flagger/values.yaml"
 spec:
   namespace: kubeaddons-flagger
   kubernetes:
@@ -32,8 +32,13 @@ spec:
   chartReference:
     chart: flagger
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.19.1
+    version: 0.20.1
     values: |
       ---
       meshProvider: istio
       metricsServer: http://prometheus-kubeaddons-prom-prometheus.kubeaddons:9090
+      flagger-loadtester:
+        service:
+          labels:
+            servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
+            kubeaddons.mesosphere.io/name: "flagger-loadtester"

--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -10,7 +10,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.38.1-22"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.38.1-23"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.38.1"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.19.2"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.20.0"
@@ -204,6 +204,17 @@ spec:
                 bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
                 tlsConfig:
                   insecureSkipVerify: true
+          - name: kubeaddons-service-monitor-metrics-flagger-loadtester
+            selector:
+              matchLabels:
+                servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
+                kubeaddons.mesosphere.io/name: "flagger-loadtester"
+            namespaceSelector:
+              matchNames:
+                - kubeaddons-flagger
+            endpoints:
+              - port: http
+                interval: 30s
         prometheusSpec:
           image:
             tag: v2.19.2

--- a/test/scripts/test-wrapper.go
+++ b/test/scripts/test-wrapper.go
@@ -102,7 +102,7 @@ func getModifiedAddons() ([]addonName, error) {
 
 func ensureModifiedAddonsHaveUpdatedRevisions(namesOfModifiedAddons []addonName, repo repositories.Repository) error {
 	for _, addonName := range namesOfModifiedAddons {
-		fmt.Printf("INFO: ensuring revision was updated for modified addon %s\n", addonName)
+		fmt.Fprintf(os.Stderr, "INFO: ensuring revision was updated for modified addon %s\n", addonName)
 
 		modifiedAddonRevisions, err := repo.GetAddon(string(addonName))
 		if err != nil {
@@ -130,7 +130,7 @@ func ensureModifiedAddonsHaveUpdatedRevisions(namesOfModifiedAddons []addonName,
 			return fmt.Errorf("the revision for addons %s was not properly updated (current: %s, previous from branch %s: %s). Please update the revision for any addons which you modify (see CONTRIBUTING.md)", addonName, modifiedVersion, upstreamBranch, upstreamVersion)
 		}
 
-		fmt.Printf("INFO: addon %s has an updated revision %s (upstream branch %s: %s)\n", addonName, modifiedVersion, upstreamBranch, upstreamVersion)
+		fmt.Fprintf(os.Stderr, "INFO: addon %s has an updated revision %s (upstream branch %s: %s)\n", addonName, modifiedVersion, upstreamBranch, upstreamVersion)
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md
2. When you're changing an existing addon, please do so with at least 2 commits:

   1. create a copy of the addon spec file without doing any changes
   2. change the copy

   That way it’s much easier to review what actually has been changed.
-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This adds a service monitor and related service labels so that Prometheus can discover flagger-loadtester's metrics endpoint.

I tested this PR by deploying KBA from this branch, browsing to `/ops/portal/prometheus/targets`, and observing that the flagger-loadtester target is present and available:

<img width="851" alt="Screen Shot 2020-10-30 at 12 10 54 PM" src="https://user-images.githubusercontent.com/42242/97749868-032edf80-1aad-11eb-87ba-21fcd22d6f90.png">

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
https://jira.d2iq.com/browse/D2IQ-72694

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Restores metrics collection for flagger-loadtester.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.