### PR TITLE
Automated chart bump ambassador-6.5.11

### DIFF
--- a/addons/ambassador/preview.yaml
+++ b/addons/ambassador/preview.yaml
@@ -9,10 +9,10 @@ metadata:
     kubeaddons.mesosphere.io/name: ambassador
     kubeaddons.mesosphere.io/provides: ingresscontroller
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.8.0-1"
-    appversion.kubeaddons.mesosphere.io/ambassador: "1.8.0"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.8.1-1"
+    appversion.kubeaddons.mesosphere.io/ambassador: "1.8.1"
     docs.kubeaddons.mesosphere.io/ambassador: "https://www.getambassador.io/docs/1.8/"
-    values.chart.helm.kubeaddons.mesosphere.io/ambassador: "https://raw.githubusercontent.com/datawire/ambassador-chart/d6d25e1/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/ambassador: "https://raw.githubusercontent.com/datawire/ambassador-chart/648d1af/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.17.11
@@ -34,7 +34,7 @@ spec:
   chartReference:
     chart: ambassador
     repo: https://getambassador.io
-    version: 6.5.9
+    version: 6.5.11
     values: |
       enableAES: false # use the OSS features
       image:


### PR DESCRIPTION
```release-note
- Bugfix: Ambassador no longer fails to configure Envoy listeners when a TracingService or LogService has a service name whose underlying cluster name has over 40 charcters.
- Bugfix: The Ambassador diagnostics page no longer returns HTTP 500 when a TracingService or LogService has a service name whose underlying cluster name has over 40 characters.
```