### PR TITLE
Add a new label for kommander to require

### DIFF
--- a/addons/cert-manager/cert-manager.yaml
+++ b/addons/cert-manager/cert-manager.yaml
@@ -4,8 +4,9 @@ metadata:
   name: cert-manager
   labels:
     kubeaddons.mesosphere.io/name: cert-manager
+    kubeaddons.mesosphere.io/cert-manager: v1
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.3-2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.3-3"
     appversion.kubeaddons.mesosphere.io/cert-manager: "1.0.3"
     docs.kubeaddons.mesosphere.io/cert-manager: "https://cert-manager.io/docs/release-notes/release-notes-1.0/"
     values.chart.helm.kubeaddons.mesosphere.io/cert-manager: "https://raw.githubusercontent.com/mesosphere/charts/57880c4/stable/cert-manager-setup/values.yaml"


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
chore, backport of https://github.com/mesosphere/kubernetes-base-addons/pull/654

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Add a new label for the kommander chart to require that only works with cert manager v1 crds.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:
My therapist says I have a preoccupation for revenge. We’ll see about that.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
