### PR TITLE
feat: adds cert-manager-upgrade automation

### DIFF
--- a/addons/cert-manager/cert-manager.yaml
+++ b/addons/cert-manager/cert-manager.yaml
@@ -6,7 +6,7 @@ metadata:
     kubeaddons.mesosphere.io/name: cert-manager
     kubeaddons.mesosphere.io/cert-manager: v1
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.3-3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.3-4"
     appversion.kubeaddons.mesosphere.io/cert-manager: "1.0.3"
     docs.kubeaddons.mesosphere.io/cert-manager: "https://cert-manager.io/docs/release-notes/release-notes-1.0/"
     values.chart.helm.kubeaddons.mesosphere.io/cert-manager: "https://raw.githubusercontent.com/mesosphere/charts/57880c4/stable/cert-manager-setup/values.yaml"
@@ -32,7 +32,7 @@ spec:
     version: 0.2.5
     values: |
       ---
-      upgradeImage: "mesosphere/kubeaddons-addon-initializer:v0.3.1"
+      upgradeImage: "mesosphere/kubeaddons-addon-initializer:v0.4.0"
       issuers:
         - name: kubernetes-root-issuer
           secretName: kubernetes-root-ca


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
https://jira.d2iq.com/browse/D2IQ-70659

**Special notes for your reviewer**:
Second time's the charm

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[cert-manager] cert-manager now supports upgrading from v0.10.1 to v1.0.3
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
