### PR TITLE
bump prometheus-operator to use forked chart

### DIFF
--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -44,7 +44,7 @@ spec:
   chartReference:
     chart: prometheus-operator
     repo: https://mesosphere.github.io/charts/staging
-    version: 9.3.1
+    version: 9.3.3
     valuesRemap:
       "prometheus.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
       "alertmanager.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
The upstream helm chart has been deprecated. This uses our fork of that chart.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
