### PR TITLE
Automated chart bump flagger-0.21.0

### DIFF
--- a/addons/flagger/flagger.yaml
+++ b/addons/flagger/flagger.yaml
@@ -8,9 +8,9 @@ metadata:
   annotations:
     sidecar.istio.io/inject: "false"
     appversion.kubeaddons.mesosphere.io/flagger: "0.19.0"
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.19.0-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.19.0-2"
     docs.kubeaddons.mesosphere.io/flagger: "https://docs.flagger.app/"
-    values.chart.helm.kubeaddons.mesosphere.io/flagger: "https://raw.githubusercontent.com/weaveworks/flagger/c6f3a87/charts/flagger/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/flagger: "https://raw.githubusercontent.com/weaveworks/flagger/2f027de/charts/flagger/values.yaml"
 spec:
   namespace: kubeaddons-flagger
   kubernetes:
@@ -32,7 +32,7 @@ spec:
   chartReference:
     chart: flagger
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.19.1
+    version: 0.21.0
     values: |
       ---
       meshProvider: istio


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This adds a chart value for setting labels on Flagger pods. This is necessary in order to allow Prometheus to scrape Flagger metrics by defining a `PodMonitor` that can discover Flagger pods by their labels.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-72693

**Special notes for your reviewer**:

I tested this chart by deploying it to a cluster with `podLabels` set and observing that the Flagger pods had those labels.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[flagger] Adds chart value `podLabels`.
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
