### PR TITLE
Add PodMonitor for flagger metrics

### DIFF
--- a/addons/flagger/flagger.yaml
+++ b/addons/flagger/flagger.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     sidecar.istio.io/inject: "false"
     appversion.kubeaddons.mesosphere.io/flagger: "0.19.0"
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.19.0-2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.19.0-3"
     docs.kubeaddons.mesosphere.io/flagger: "https://docs.flagger.app/"
     values.chart.helm.kubeaddons.mesosphere.io/flagger: "https://raw.githubusercontent.com/mesosphere/charts/f4105ebb01fc758a4af356069a8ceae043201057/staging/flagger/values.yaml"
 spec:
@@ -32,11 +32,14 @@ spec:
   chartReference:
     chart: flagger
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.20.1
+    version: 0.21.0
     values: |
       ---
       meshProvider: istio
       metricsServer: http://prometheus-kubeaddons-prom-prometheus.kubeaddons:9090
+      podLabels:
+        podmonitor.kubeaddons.mesosphere.io/path: "metrics"
+        kubeaddons.mesosphere.io/name: "flagger"
       flagger-loadtester:
         service:
           labels:

--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -10,7 +10,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.38.1-24"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.38.1-25"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.38.1"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.22.2"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.20.0"
@@ -215,6 +215,19 @@ spec:
             endpoints:
               - port: http
                 interval: 30s
+        additionalPodMonitors:
+          - name: kubeaddons-pod-monitor-metrics-flagger
+            selector:
+              matchLabels:
+                podmonitor.kubeaddons.mesosphere.io/path: "metrics"
+                kubeaddons.mesosphere.io/name: "flagger"
+            namespaceSelector:
+              matchNames:
+                - kubeaddons-flagger
+            podMetricsEndpoints:
+              - port: http
+                interval: 30s
+                scheme: http
         prometheusSpec:
           image:
             tag: v2.22.2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This restores Flagger's metrics by adding a corresponding PodMonitor to Prometheus config.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
https://jira.d2iq.com/browse/D2IQ-72693

**Special notes for your reviewer**:

I tested this PR by deploying a Konvoy cluster with the KBA configversion set to this branch, and the flagger and istio addons enabled. I then browsed to `/ops/portal/prometheus/targets` and saw that the target for flagger pods is present.

<img width="981" alt="Screen Shot 2020-11-24 at 5 15 51 PM" src="https://user-images.githubusercontent.com/42242/100169720-fcf80d00-2e78-11eb-9c20-e52e189bf411.png">

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[flagger] Restores missing flagger metrics.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
