### PR TITLE
chore(fluentbit): chart bump 0.7.8 and tail-db

### DIFF
--- a/addons/fluentbit/fluentbit.yaml
+++ b/addons/fluentbit/fluentbit.yaml
@@ -71,7 +71,7 @@ spec:
           fieldRef:
             fieldPath: spec.nodeName
       extraVolumes:
-      # we create this to have a persistend tail-db directory an all nodes
+      # we create this to have a persistent tail-db directory an all nodes
       # otherwise a restarted fluent-bit would rescrape all tails
       - name: tail-db
         hostPath:

--- a/addons/fluentbit/fluentbit.yaml
+++ b/addons/fluentbit/fluentbit.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: fluentbit
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.7-2"
-    appversion.kubeaddons.mesosphere.io/fluentbit: "1.5.7"
-    values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/fluent/helm-charts/8b430b9/charts/fluent-bit/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.6-1"
+    appversion.kubeaddons.mesosphere.io/fluentbit: "1.6.6"
+    values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/fluent/helm-charts/35bb2a7/charts/fluent-bit/values.yaml"
     # the older versions were being deployed from stable/fluent-bit
     # and were versioned like 2.8.x
     helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \">=2.8.0\", \"strategy\": \"delete\"}]"
@@ -35,7 +35,7 @@ spec:
   chartReference:
     chart: fluent-bit
     repo: https://fluent.github.io/helm-charts
-    version: 0.7.3
+    version: 0.7.8
     values: |
       service:
         labels:
@@ -71,8 +71,12 @@ spec:
           fieldRef:
             fieldPath: spec.nodeName
       extraVolumes:
+      # we create this to have a persistend tail-db directory an all nodes
+      # otherwise a restarted fluent-bit would rescrape all tails
       - name: tail-db
-        emptyDir: {}
+        hostPath:
+          path: /var/log/tail-db
+          type: DirectoryOrCreate
       # we create this to get rid of error messages that would appear on non control-plane nodes
       - name: kubernetes-audit
         hostPath:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
- latest fluent-bit version 1.6.6
- create persisted host tail-db dir, NOT emptydir
it would lose the data with a pod restart

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
no issue

**Special notes for your reviewer**:
waiting for https://github.com/fluent/helm-charts/pull/47 to be merged

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fluent-bit v1.6.6 (https://fluentbit.io/announcements/v1.6.6)
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.