### PR TITLE
bug(fluentbit): ES mapping correction / modify

### DIFF
--- a/addons/fluentbit/fluentbit.yaml
+++ b/addons/fluentbit/fluentbit.yaml
@@ -172,7 +172,7 @@ spec:
               Record host ${FLUENT_BIT_NODE_NAME}
           # We are adding the following filters here to have the workaround for
           # labels kubernetes.label.app=foobar.
-          # Elasticsearch cannot accept single strings and beneath it new objects,
+          # Elasticsearch cannot accept single strings and beneath its new objects,
           # so it will reject all new entries when there is any kubernetes.label.app=foobar
           # entry already present. So what we do is that we remap / modify the kubernetes.label.app
           # to be kubernetes.label.app.kubernetes.io/name.

--- a/addons/fluentbit/fluentbit.yaml
+++ b/addons/fluentbit/fluentbit.yaml
@@ -172,7 +172,7 @@ spec:
               Record host ${FLUENT_BIT_NODE_NAME}
           # We are adding the following filters here to have the workaround for
           # labels kubernetes.label.app=foobar.
-          # Elasticsearch cannot accept single strings and beneth it new objects,
+          # Elasticsearch cannot accept single strings and beneath it new objects,
           # so it will reject all new entries when there is any kubernetes.label.app=foobar
           # entry already present. So what we do is that we remap / modify the kubernetes.label.app
           # to be kubernetes.label.app.kubernetes.io/name.

--- a/addons/fluentbit/fluentbit.yaml
+++ b/addons/fluentbit/fluentbit.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: fluentbit
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.6-1"
-    appversion.kubeaddons.mesosphere.io/fluentbit: "1.6.6"
-    values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/fluent/helm-charts/35bb2a7/charts/fluent-bit/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.8-1"
+    appversion.kubeaddons.mesosphere.io/fluentbit: "1.6.8"
+    values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/fluent/helm-charts/86e50f1/charts/fluent-bit/values.yaml"
     # the older versions were being deployed from stable/fluent-bit
     # and were versioned like 2.8.x
     helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \">=2.8.0\", \"strategy\": \"delete\"}]"
@@ -35,7 +35,7 @@ spec:
   chartReference:
     chart: fluent-bit
     repo: https://fluent.github.io/helm-charts
-    version: 0.7.8
+    version: 0.7.12
     values: |
       service:
         labels:
@@ -170,6 +170,46 @@ spec:
               Name record_modifier
               Match kernel
               Record host ${FLUENT_BIT_NODE_NAME}
+          # We are adding the following filters here to have the workaround for
+          # labels kubernetes.label.app=foobar.
+          # Elasticsearch cannot accept single strings and beneth it new objects,
+          # so it will reject all new entries when there is any kubernetes.label.app=foobar
+          # entry already present. So what we do is that we remap / modify the kubernetes.label.app
+          # to be kubernetes.label.app.kubernetes.io/name.
+          [FILTER]
+              Name                nest
+              Match               kube.*
+              Operation           lift
+              Nested_under        kubernetes
+              Add_prefix          kubernetes_
+          [FILTER]
+              Name                nest
+              Match               kube.*
+              Operation           lift
+              Nested_under        kubernetes_labels
+              Add_prefix          kubernetes_labels_
+          [FILTER]
+              Name                modify
+              Match               kube.*
+              Hard_rename         kubernetes_labels_app kubernetes_labels_app.kubernetes.io/name
+          [FILTER]
+              Name                nest
+              Match               kube.*
+              Operation           nest
+              Wildcard            kubernetes_labels_*
+              Nest_under          kubernetes.labels
+              Remove_prefix       kubernetes_labels_
+          [FILTER]
+              Name                nest
+              Match               kube.*
+              Operation           nest
+              Wildcard            kubernetes_*
+              Nest_under          kubernetes
+              Remove_prefix       kubernetes_
+          [FILTER]
+              Name                modify
+              Match               kube.*
+              Remove_wildcard     kubernetes_
 
         ## https://docs.fluentbit.io/manual/pipeline/outputs
         outputs: |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
- We are adding the filters here to have the workaround for labels 
kubernetes.label.app=foobar.
Elasticsearch cannot accept strings on a field and beneath it new 
objects.
So it will reject all new entries when there is any 
kubernetes.label.app=foobar (string)
entry already present in an index. So we remap / modify the 
kubernetes.label.app to be kubernetes.label.app.kubernetes.io/name. (see https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
-- adapted from https://github.com/fluent/fluent-bit/issues/483#issuecomment-593393980


- also updated to latest fluent-bit chart and version 1.6.8

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
jql=key in (D2IQ-73455)

[D2IQ-73455]

[D2IQ-73455]: https://jira.d2iq.com/browse/D2IQ-73455


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- modify `kubernetes.label.app` to `kubernetes.label.app.kubernetes.io/name`
- Fluent Bit 1.6.8
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.