### PR TITLE
[WIP] chore: point kibana chart to official

### DIFF
--- a/addons/kibana/kibana.yaml
+++ b/addons/kibana/kibana.yaml
@@ -30,22 +30,63 @@ spec:
         kubeaddons.mesosphere.io/name: elasticsearch
   chartReference:
     chart: kibana
-    repo: https://mesosphere.github.io/charts/stable
+    repo: https://helm.elastic.co
     version: 3.2.7
     valuesRemap:
       "ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
     values: |
       ---
+      elasticsearchHosts: "http://elasticsearch-kubeaddons-master:9200"
+
+      # This value file is from the 6.8 branch of elastic/helm-charts
+      # The repository may need to be re-evaluated for later versions
+      # Same image is used on the dahsboard, changes should be reflected there
       image:
+        repository: "docker.elastic.co/kibana/kibana-oss"
         tag: 6.8.10
-      files:
-        kibana.yml:
+
+      # Originally called files on helm/stable
+      kibanaConfig:
+        kibana.yml: |
           ## Default Kibana configuration from kibana-docker.
           elasticsearch.url: http://elasticsearch-kubeaddons-client:9200
           ## Ref: https://www.elastic.co/guide/en/kibana/current/settings.html
           server.basePath: /ops/portal/kibana
-      serviceAccount:
-        create: true
+        dashboardImport.sh: |
+          #!/usr/bin/env bash
+          #
+          # kibana dashboard import script
+          #
+          cd /kibanadashboards
+          echo "Starting Kibana..."
+          /usr/local/bin/kibana-docker $@ &
+          echo "Waiting up to {{ .Values.dashboardImport.timeout }} seconds for Kibana to get in green overall state..."
+          for i in {1..{{ .Values.dashboardImport.timeout }}}; do
+            curl -s localhost:5601{{ .Values.dashboardImport.basePath }}/api/status | python -c 'import sys, json; print json.load(sys.stdin)["status"]["overall"]["state"]' 2> /dev/null | grep green > /dev/null && break || sleep 1
+          done
+          for DASHBOARD_FILE in *; do
+            echo -e "Importing ${DASHBOARD_FILE} dashboard..."
+            if ! python -c 'import sys, json; print json.load(sys.stdin)' < "${DASHBOARD_FILE}" &> /dev/null ; then
+              echo "${DASHBOARD_FILE} is not valid JSON, assuming it's an URL..."
+              TMP_FILE="$(mktemp)"
+              curl -s $(cat ${DASHBOARD_FILE}) > ${TMP_FILE}
+              curl -v {{ if .Values.dashboardImport.xpackauth.enabled }}--user {{ .Values.dashboardImport.xpackauth.username }}:{{ .Values.dashboardImport.xpackauth.password }}{{ end }} -s --connect-timeout 60 --max-time 60 -XPOST localhost:5601{{ .Values.dashboardImport.basePath }}/api/kibana/dashboards/import?force=true -H 'kbn-xsrf:true' -H 'Content-type:application/json' -d @${TMP_FILE}
+              rm ${TMP_FILE}
+            else
+              echo "Valid JSON found in ${DASHBOARD_FILE}, importing..."
+              curl -v {{ if .Values.dashboardImport.xpackauth.enabled }}--user {{ .Values.dashboardImport.xpackauth.username }}:{{ .Values.dashboardImport.xpackauth.password }}{{ end }} -s --connect-timeout 60 --max-time 60 -XPOST localhost:5601{{ .Values.dashboardImport.basePath }}/api/kibana/dashboards/import?force=true -H 'kbn-xsrf:true' -H 'Content-type:application/json' -d @./${DASHBOARD_FILE}
+            fi
+            if [ "$?" != "0" ]; then
+              echo -e "\nImport of ${DASHBOARD_FILE} dashboard failed... Exiting..."
+              exit 1
+            else
+              echo -e "\nImport of ${DASHBOARD_FILE} dashboard finished :-)"
+            fi
+          done
+        dashboards: |-
+          audit-logs-dashboards: '{"objects":[{"id":"19422f60-93e2-11e8-83ef-b5593250e6b7","type":"dashboard","attributes":{"title":"Audit-Dashboard","hits":0,"description":"Dashboard for Audit-Logs","panelsJSON":"[{\"embeddableConfig\":{\"columns\":[\"objectRef.namespace\",\"user.username\",\"sourceIPs\",\"verb\",\"objectRef.resource\",\"requestURI\"]},\"gridData\":{\"x\":13,\"y\":0,\"w\":35,\"h\":74,\"i\":\"1\"},\"id\":\"bb4f4e80-93e9-11e8-83ef-b5593250e6b7\",\"panelIndex\":\"1\",\"type\":\"search\",\"version\":\"6.8.2\"},{\"embeddableConfig\":{\"spy\":null,\"vis\":{\"legendOpen\":false}},\"gridData\":{\"x\":0,\"y\":0,\"w\":13,\"h\":14,\"i\":\"2\"},\"id\":\"07098510-93cb-11ea-a17b-e52b18339f68\",\"panelIndex\":\"2\",\"type\":\"visualization\",\"version\":\"6.8.2\"},{\"embeddableConfig\":{\"spy\":null,\"vis\":{\"legendOpen\":false}},\"gridData\":{\"x\":0,\"y\":14,\"w\":13,\"h\":24,\"i\":\"3\"},\"id\":\"324f3710-93eb-11e8-83ef-b5593250e6b7\",\"panelIndex\":\"3\",\"type\":\"visualization\",\"version\":\"6.8.2\"},{\"gridData\":{\"x\":0,\"y\":38,\"w\":13,\"h\":14,\"i\":\"4\"},\"id\":\"429087b0-9584-11e8-a471-e1cc12dab5c6\",\"panelIndex\":\"4\",\"type\":\"visualization\",\"version\":\"6.8.2\"},{\"gridData\":{\"x\":0,\"y\":52,\"w\":13,\"h\":11,\"i\":\"5\"},\"id\":\"38b93150-9585-11e8-a471-e1cc12dab5c6\",\"panelIndex\":\"5\",\"type\":\"visualization\",\"version\":\"6.8.2\"},{\"gridData\":{\"x\":0,\"y\":63,\"w\":13,\"h\":11,\"i\":\"6\"},\"id\":\"138c2220-9585-11e8-a471-e1cc12dab5c6\",\"panelIndex\":\"6\",\"type\":\"visualization\",\"version\":\"6.8.2\"}]","optionsJSON":"{\"darkTheme\":true,\"hidePanelTitles\":false,\"useMargins\":false}","version":1,"timeRestore":false,"kibanaSavedObjectMeta":{"searchSourceJSON":"{\"query\":{\"language\":\"lucene\",\"query\":\"\"},\"filter\":[],\"highlightAll\":true,\"version\":true}"}}},{"id":"dbd12d90-93c9-11ea-a17b-e52b18339f68","type":"search","attributes":{"title":"Audit-Search: Pods","description":"Audit log search for pods with a `namespace that exists` filter applied","hits":0,"columns":["objectRef.namespace","user.username","sourceIPs","verb","requestURI"],"sort":["@timestamp","desc"],"version":1,"kibanaSavedObjectMeta":{"searchSourceJSON":"{\"index\":\"kubernetes_audit\",\"highlightAll\":true,\"version\":true,\"query\":{\"query\":\"apiVersion:\\\"audit.k8s.io/v1\\\" AND objectRef.resource:\\\"pods\\\"\",\"language\":\"lucene\"},\"filter\":[{\"meta\":{\"index\":\"kubernetes_audit\",\"negate\":false,\"disabled\":false,\"alias\":null,\"type\":\"exists\",\"key\":\"objectRef.namespace\",\"value\":\"exists\"},\"exists\":{\"field\":\"objectRef.namespace\"},\"$state\":{\"store\":\"appState\"}}]}"}}},{"id":"bb4f4e80-93e9-11e8-83ef-b5593250e6b7","type":"search","attributes":{"title":"Audit-Search","description":"","hits":0,"columns":["objectRef.namespace","user.username","sourceIPs","verb","objectRef.resource","requestURI"],"sort":["@timestamp","desc"],"version":1,"kibanaSavedObjectMeta":{"searchSourceJSON":"{\"index\":\"kubernetes_audit\",\"highlightAll\":true,\"version\":true,\"query\":{\"query\":\"apiVersion:\\\"audit.k8s.io/v1\\\"\",\"language\":\"lucene\"},\"filter\":[]}"}}},{"id":"07098510-93cb-11ea-a17b-e52b18339f68","type":"visualization","attributes":{"title":"Audit-Visualization: Namespace","visState":"{\"title\":\"Audit-Visualization: Namespace\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"},\"valueAxis\":null},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100,\"rotate\":90},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":false,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":true,\"mode\":\"stacked\",\"type\":\"histogram\",\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"data\":{\"id\":\"2\",\"label\":\"Count\"},\"valueAxis\":\"ValueAxis-1\"}],\"addTooltip\":false,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"2\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"objectRef.namespace.keyword\",\"size\":20,\"order\":\"desc\",\"orderBy\":\"2\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}","uiStateJSON":"{\"spy\":null,\"vis\":{\"legendOpen\":false}}","description":"","savedSearchId":"bb4f4e80-93e9-11e8-83ef-b5593250e6b7","version":1,"kibanaSavedObjectMeta":{"searchSourceJSON":"{\"filter\":[],\"query\":{\"language\":\"lucene\",\"query\":\"\"}}"}},"_migrationVersion":{"visualization":"6.7.2"}},{"id":"429087b0-9584-11e8-a471-e1cc12dab5c6","type":"visualization","attributes":{"title":"Audit-Visualization: Source-Ips","visState":"{\n  \"title\": \"Audit-Visualization: Source-Ips\",\n  \"type\": \"histogram\",\n  \"params\": {\n    \"type\": \"histogram\",\n    \"grid\": {\n      \"categoryLines\": false,\n      \"style\": {\n        \"color\": \"#eee\"\n      }\n    },\n    \"categoryAxes\": [\n      {\n        \"id\": \"CategoryAxis-1\",\n        \"type\": \"category\",\n        \"position\": \"bottom\",\n        \"show\": true,\n        \"style\": {},\n        \"scale\": {\n          \"type\": \"linear\"\n        },\n        \"labels\": {\n          \"show\": true,\n          \"truncate\": 100\n        },\n        \"title\": {}\n      }\n    ],\n    \"valueAxes\": [\n      {\n        \"id\": \"ValueAxis-1\",\n        \"name\": \"LeftAxis-1\",\n        \"type\": \"value\",\n        \"position\": \"left\",\n        \"show\": false,\n        \"style\": {},\n        \"scale\": {\n          \"type\": \"linear\",\n          \"mode\": \"normal\"\n        },\n        \"labels\": {\n          \"show\": true,\n          \"rotate\": 0,\n          \"filter\": false,\n          \"truncate\": 100\n        },\n        \"title\": {\n          \"text\": \"Count\"\n        }\n      }\n    ],\n    \"seriesParams\": [\n      {\n        \"show\": true,\n        \"mode\": \"stacked\",\n        \"type\": \"histogram\",\n        \"drawLinesBetweenPoints\": true,\n        \"showCircles\": true,\n        \"data\": {\n          \"id\": \"2\",\n          \"label\": \"Count\"\n        },\n        \"valueAxis\": \"ValueAxis-1\"\n      }\n    ],\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"legendPosition\": \"right\",\n    \"times\": [],\n    \"addTimeMarker\": false\n  },\n  \"aggs\": [\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"3\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"sourceIPs.keyword\",\n        \"size\": 20,\n        \"order\": \"desc\",\n        \"orderBy\": \"2\",\n        \"otherBucket\": false,\n        \"otherBucketLabel\": \"Other\",\n        \"missingBucket\": false,\n        \"missingBucketLabel\": \"Missing\"\n      }\n    }\n  ]\n}","uiStateJSON":"{}","description":"","savedSearchId":"bb4f4e80-93e9-11e8-83ef-b5593250e6b7","version":1,"kibanaSavedObjectMeta":{"searchSourceJSON":"{\n  \"filter\": [],\n  \"query\": {\n    \"query\": \"\",\n    \"language\": \"lucene\"\n  }\n}"}},"_migrationVersion":{"visualization":"6.7.2"}},{"id":"324f3710-93eb-11e8-83ef-b5593250e6b7","type":"visualization","attributes":{"title":"Audit-Visualization: User","visState":"{\"title\":\"Audit-Visualization: User\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":30},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":false,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\",\"defaultYExtents\":false,\"setYExtents\":false},\"labels\":{\"show\":false,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":true,\"mode\":\"stacked\",\"type\":\"histogram\",\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"data\":{\"id\":\"2\",\"label\":\"Count\"},\"valueAxis\":\"ValueAxis-1\"}],\"addTooltip\":false,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"2\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"user.username.keyword\",\"size\":20,\"order\":\"desc\",\"orderBy\":\"2\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}","uiStateJSON":"{\"spy\":null,\"vis\":{\"legendOpen\":false}}","description":"","savedSearchId":"bb4f4e80-93e9-11e8-83ef-b5593250e6b7","version":1,"kibanaSavedObjectMeta":{"searchSourceJSON":"{\"filter\":[],\"query\":{\"language\":\"lucene\",\"query\":\"\"}}"}},"_migrationVersion":{"visualization":"6.7.2"}},{"id":"38b93150-9585-11e8-a471-e1cc12dab5c6","type":"visualization","attributes":{"title":"Audit-Visualization: Verb","visState":"{\n  \"title\": \"Audit-Visualization: Verb\",\n  \"type\": \"histogram\",\n  \"params\": {\n    \"type\": \"histogram\",\n    \"grid\": {\n      \"categoryLines\": false,\n      \"style\": {\n        \"color\": \"#eee\"\n      }\n    },\n    \"categoryAxes\": [\n      {\n        \"id\": \"CategoryAxis-1\",\n        \"type\": \"category\",\n        \"position\": \"bottom\",\n        \"show\": true,\n        \"style\": {},\n        \"scale\": {\n          \"type\": \"linear\"\n        },\n        \"labels\": {\n          \"show\": true,\n          \"truncate\": 100\n        },\n        \"title\": {}\n      }\n    ],\n    \"valueAxes\": [\n      {\n        \"id\": \"ValueAxis-1\",\n        \"name\": \"LeftAxis-1\",\n        \"type\": \"value\",\n        \"position\": \"left\",\n        \"show\": false,\n        \"style\": {},\n        \"scale\": {\n          \"type\": \"linear\",\n          \"mode\": \"normal\"\n        },\n        \"labels\": {\n          \"show\": true,\n          \"rotate\": 0,\n          \"filter\": false,\n          \"truncate\": 100\n        },\n        \"title\": {\n          \"text\": \"Count\"\n        }\n      }\n    ],\n    \"seriesParams\": [\n      {\n        \"show\": true,\n        \"mode\": \"stacked\",\n        \"type\": \"histogram\",\n        \"drawLinesBetweenPoints\": true,\n        \"showCircles\": true,\n        \"data\": {\n          \"id\": \"2\",\n          \"label\": \"Count\"\n        },\n        \"valueAxis\": \"ValueAxis-1\"\n      }\n    ],\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"legendPosition\": \"right\",\n    \"times\": [],\n    \"addTimeMarker\": false\n  },\n  \"aggs\": [\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"3\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"verb.keyword\",\n        \"size\": 20,\n        \"order\": \"desc\",\n        \"orderBy\": \"2\",\n        \"otherBucket\": false,\n        \"otherBucketLabel\": \"Other\",\n        \"missingBucket\": false,\n        \"missingBucketLabel\": \"Missing\"\n      }\n    }\n  ]\n}","uiStateJSON":"{}","description":"","savedSearchId":"bb4f4e80-93e9-11e8-83ef-b5593250e6b7","version":1,"kibanaSavedObjectMeta":{"searchSourceJSON":"{\n  \"filter\": [],\n  \"query\": {\n    \"query\": \"\",\n    \"language\": \"lucene\"\n  }\n}"}}},{"id":"138c2220-9585-11e8-a471-e1cc12dab5c6","type":"visualization","attributes":{"title":"Audit-Visualization: Resource","visState":"{\"title\":\"Audit-Visualization: Resource\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":30},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":false,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":true,\"mode\":\"stacked\",\"type\":\"histogram\",\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"data\":{\"id\":\"2\",\"label\":\"Count\"},\"valueAxis\":\"ValueAxis-1\"}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"2\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"objectRef.resource.keyword\",\"size\":20,\"order\":\"desc\",\"orderBy\":\"2\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}","uiStateJSON":"{}","description":"","savedSearchId":"bb4f4e80-93e9-11e8-83ef-b5593250e6b7","version":1,"kibanaSavedObjectMeta":{"searchSourceJSON":"{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"}}}]}'
+
+
       service:
         type: ClusterIP
         externalPort: 5601
@@ -58,6 +99,7 @@ spec:
           cpu: 1000m
         requests:
           cpu: 100m
+
       plugins:
         # to avoid needing to download any plugins at runtime, use a container and a shared volume
         # do not enable the plugins here, instead rebuild the mesosphere/kibana-plugins image with the new plugins
@@ -97,7 +139,7 @@ spec:
                 exit 1
               fi
               sleep infinity
-      initContainers:
+      extraInitContainers:
         # from https://github.com/mesosphere/kubeaddons-sidecars
         - name: kibana-plugins-install
           image: mesosphere/kibana-plugins:v6.8.10
@@ -105,6 +147,26 @@ spec:
           volumeMounts:
           - name: plugins
             mountPath: /usr/share/kibana/shared-plugins/
+        # dashboard imports
+        - name: kibana-dashboardimport
+          image: "docker.elastic.co/kibana/kibana-oss:6.8.10"
+          imagePullPolicy: "IfNotPresent"
+          command: ["/bin/bash"]
+          args:
+            - "-c"
+            - "/tmp/dashboardImport.sh"
+          volumeMounts:
+          - name: {{ template "kibana.fullname" . }}-dashboards
+            mountPath: "/kibanadashboards"
+          - name: {{ template "kibana.fullname" . }}-importscript
+            mountPath: "/tmp/dashboardImport.sh"
+            subPath: dashboardImport.sh
+          - name: kibanaConfig
+            mountPath: "/usr/share/kibana/config/kibana.yml"
+            subPath: kibana.yml
+          - name: dashboardsImports
+            mountPath: "/usr/share/kibana/config/dashboardImport.sh"
+            subPath: dashboardImport.sh
       extraVolumes:
         - name: plugins
           emptyDir: {}
@@ -122,6 +184,8 @@ spec:
           traefik.ingress.kubernetes.io/priority: "2"
         hosts:
           - "/ops/portal/kibana"
+
+      # this moves now to the configmap
       dashboardImport:
         enabled: true
         timeout: 180


### PR DESCRIPTION
Moving kibana chart to the official chart is what we are working on.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:
This is by no means done, translations are still happening and this is just the middle. 


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Updated to official chart
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
