### PR TITLE
Revert Prometheus upgrade

### DIFF
--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -10,9 +10,9 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.38.1-26"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.38.1-27"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.38.1"
-    appversion.kubeaddons.mesosphere.io/prometheus: "2.22.2"
+    appversion.kubeaddons.mesosphere.io/prometheus: "2.19.2"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.20.0"
     appversion.kubeaddons.mesosphere.io/grafana: "6.7.3"
     endpoint.kubeaddons.mesosphere.io/prometheus: "/ops/portal/prometheus"
@@ -230,7 +230,7 @@ spec:
                 scheme: http
         prometheusSpec:
           image:
-            tag: v2.22.2
+            tag: v2.19.2
           thanos:
             version: v0.8.1
           externalLabels:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

This PR reverts #681. Prometheus-operator v0.38.1 does not support prometheus v2.22.2, and has issues with it. We will attempt to upgrade prometheus again after we upgrade prometheus-operator (see https://jira.d2iq.com/browse/D2IQ-73452).

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
\[prometheus\] Downgrades Prometheus to v2.19.2 to fix compatibility issues with prometheus-operator v0.38.1.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
