### PR TITLE
[backport release/2] velero: use kubeaddons-addon-initialize v0.4.3

### DIFF
--- a/addons/velero/velero.yaml
+++ b/addons/velero/velero.yaml
@@ -31,8 +31,8 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.1-7"
-    values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/mesosphere/charts/5327e6a54fe70df550e894fd754541a4f71a9054/staging/velero/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.1-8"
+    values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/mesosphere/charts/51eb074b28fd5a8e5299d0041ce4ed38122e20d7/staging/velero/values.yaml"
 spec:
   namespace: velero
   kubernetes:
@@ -81,7 +81,7 @@ spec:
             servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
       initContainers:
       - name: initialize-velero
-        image: mesosphere/kubeaddons-addon-initializer:v0.2.5
+        image: mesosphere/kubeaddons-addon-initializer:v0.4.3
         args: ["velero"]
         env:
         - name: "VELERO_MINIO_FALLBACK_SECRET_NAME"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
This fixes the issue that was making it impossible to use a custom S3Url in Velero.

**Which issue(s) this PR fixes**:
* https://jira.d2iq.com/browse/D2IQ-73435

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [X] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
