### PR TITLE
fix: set correct branch to get modified addons

### DIFF
--- a/test/addons_test.go
+++ b/test/addons_test.go
@@ -38,9 +38,12 @@ const (
 	defaultKindestNodeImage = "kindest/node:v1.18.8"
 	patchStorageClass       = `{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}`
 
-	comRepoURL    = "https://github.com/mesosphere/kubeaddons-community"
-	comRepoRef    = "master"
-	comRepoRemote = "origin"
+	repoRef    = "release/2"
+	repoRemote = "origin"
+
+	communityRepoURL    = "https://github.com/mesosphere/kubeaddons-community"
+	communityRepoRef    = "master"
+	communityRepoRemote = "origin"
 )
 
 var (
@@ -61,8 +64,8 @@ func init() {
 		panic(err)
 	}
 
-	fmt.Printf("initializing remote repository %s for test...\n", comRepoURL)
-	comRepo, err = git.NewRemoteRepository(comRepoURL, comRepoRef, comRepoRemote)
+	fmt.Printf("initializing remote repository %s for test...\n", communityRepoURL)
+	comRepo, err = git.NewRemoteRepository(communityRepoURL, communityRepoRef, communityRepoRemote)
 	if err != nil {
 		panic(err)
 	}
@@ -276,16 +279,16 @@ func testgroup(t *testing.T, groupname string, version string, jobs ...clusterTe
 	addonUpgrades := testharness.Loadables{}
 	for _, newAddon := range addons {
 		t.Logf("verifying whether upgrade testing is needed for addon %s", newAddon.GetName())
-		oldAddon, err := addontesters.GetLatestAddonRevisionFromLocalRepoBranch("../", comRepoRemote, comRepoRef, newAddon.GetName())
+		oldAddon, err := addontesters.GetLatestAddonRevisionFromLocalRepoBranch("../", repoRemote, repoRef, newAddon.GetName())
 		if err != nil {
 			if strings.Contains(err.Error(), "directory not found") {
-				t.Logf("no need to upgrade test %s, it appears to be a new addon (no previous revisions found in branch %s)", newAddon.GetName(), comRepoRef)
+				t.Logf("no need to upgrade test %s, it appears to be a new addon (no previous revisions found in branch %s)", newAddon.GetName(), repoRef)
 				continue
 			}
 			return err
 		}
 		if oldAddon == nil {
-			t.Logf("no need to upgrade test %s, it appears to be a new addon (no previous revisions found in branch %s)", newAddon.GetName(), comRepoRef)
+			t.Logf("no need to upgrade test %s, it appears to be a new addon (no previous revisions found in branch %s)", newAddon.GetName(), repoRef)
 			continue // new addon, upgrade test not needed
 		}
 

--- a/test/scripts/test-wrapper.go
+++ b/test/scripts/test-wrapper.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	upstreamRemote = "origin"
-	upstreamBranch = "master"
+	upstreamBranch = "release/2"
 )
 
 type addonName string
@@ -78,7 +78,7 @@ func main() {
 func getModifiedAddons() ([]addonName, error) {
 	addonsModifiedMap := make(map[addonName]struct{})
 	stdout := new(bytes.Buffer)
-	cmd := exec.Command("git", "diff", "origin/master", "--name-only")
+	cmd := exec.Command("git", "diff", fmt.Sprintf("%s/%s", upstreamRemote, upstreamBranch), "--name-only")
 	cmd.Stdout = stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
This needs to be the branch otherwise we get wrong errors when doing PRs against the branch `release/2`.

**Which issue(s) this PR fixes**:
No issue.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [X] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
