### PR TITLE
Remove elasticsearch requirement from fluentbit

### DIFF
--- a/addons/elasticsearch/elasticsearch.yaml
+++ b/addons/elasticsearch/elasticsearch.yaml
@@ -10,7 +10,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.2-9"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.2-10"
     appversion.kubeaddons.mesosphere.io/elasticsearch: "6.8.2"
     values.chart.helm.kubeaddons.mesosphere.io/elasticsearch: "https://raw.githubusercontent.com/mesosphere/charts/73fba37/stable/elasticsearch/values.yaml"
     # Some StatefulSet changes can't be applied, so we need to delete and recreate.

--- a/addons/elasticsearch/elasticsearch.yaml
+++ b/addons/elasticsearch/elasticsearch.yaml
@@ -35,6 +35,11 @@ spec:
     version: 1.32.0
     values: |
       ---
+      cluster:
+        config:
+          # Disable automatic creation of audit log indexes.
+          # This is intended to reject audit logs until their index template has been created. See data.hooks.postStart.
+          action.auto_create_index: "-kubernetes_audit*"
       client:
         heapSize: 1024m
         resources:
@@ -88,6 +93,16 @@ spec:
                 echo "Error within _template 'kubernetes_audit' creation - exiting"
                 exit 1
               fi
+            fi
+
+            # Enable automatic creation of all indexes.
+            # This re-enables the creation of audit log indexes now that their index template exists. See cluster.config.
+            RES_SETTINGS=$(curl -XPUT -s -o /dev/null -w '%{http_code}' ${CLIENT_URL}/_cluster/settings \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d '{"persistent": {"action.auto_create_index": "true"}}')
+            if [[ "${RES_SETTINGS}" != "200" ]]; then
+              echo "Error applying cluster settings - exiting"
+              exit 1
             fi
         heapSize: 3072m
         resources:

--- a/addons/elasticsearch/elasticsearch.yaml
+++ b/addons/elasticsearch/elasticsearch.yaml
@@ -13,6 +13,9 @@ metadata:
     catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.2-9"
     appversion.kubeaddons.mesosphere.io/elasticsearch: "6.8.2"
     values.chart.helm.kubeaddons.mesosphere.io/elasticsearch: "https://raw.githubusercontent.com/mesosphere/charts/73fba37/stable/elasticsearch/values.yaml"
+    # Some StatefulSet changes can't be applied, so we need to delete and recreate.
+    helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=6.8.2\", \"strategy\": \"delete\"}]"
+    helm2.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=6.8.2\", \"strategy\": \"delete\"}]"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/addons/fluentbit/fluentbit.yaml
+++ b/addons/fluentbit/fluentbit.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: fluentbit
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.8-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.8-2"
     appversion.kubeaddons.mesosphere.io/fluentbit: "1.6.8"
     values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/fluent/helm-charts/86e50f1/charts/fluent-bit/values.yaml"
     # the older versions were being deployed from stable/fluent-bit
@@ -16,11 +16,6 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
-  requires:
-    # This allows us to have fluentbit wait until ES is deployed and has the right configurations up, in particular
-    # setting up index templates
-    - matchLabels:
-        kubeaddons.mesosphere.io/name: elasticsearch
   cloudProvider:
     - name: aws
       enabled: true

--- a/test/addons_test.go
+++ b/test/addons_test.go
@@ -3,9 +3,11 @@ package test
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -44,6 +46,11 @@ const (
 	comRepoRemote = "origin"
 
 	allAWSGroupName = "allAWS"
+
+	tempDir = "/tmp/kubernetes-base-addons"
+
+	kubeaddonsControllerNamespace = "kubeaddons"
+	kubeaddonsControllerPodPrefix = "kubeaddons-controller-manager-"
 )
 
 var (
@@ -268,6 +275,14 @@ func testgroup(t *testing.T, groupname string, version string, jobs ...clusterTe
 		}
 	}()
 
+	if err := os.MkdirAll(tempDir, 0755); err != nil {
+		return err
+	}
+	dir, err := ioutil.TempDir(tempDir, groupname+"-")
+	if err != nil {
+		return err
+	}
+
 	t.Logf("setting up cluster for test group %s", groupname)
 	tcluster, err := newCluster(groupname, version, node, t)
 	if err != nil {
@@ -282,21 +297,17 @@ func testgroup(t *testing.T, groupname string, version string, jobs ...clusterTe
 	}
 	defer tcluster.Cleanup()
 
-	f, err := ioutil.TempFile(os.TempDir(), "konvoy-test-")
-	if err != nil {
-		return err
-	}
-
 	kubeConfig, err := tcluster.ConfigYAML()
 	if err != nil {
 		return err
 	}
 
-	if _, err := f.Write(kubeConfig); err != nil {
+	kubeConfigPath := filepath.Join(dir, "kubeconfig")
+	if err := ioutil.WriteFile(kubeConfigPath, kubeConfig, 0644); err != nil {
 		return err
 	}
 
-	if err := kubectl("--kubeconfig", f.Name(), "apply", "-f", controllerBundle); err != nil {
+	if err := kubectl("--kubeconfig", kubeConfigPath, "apply", "-f", controllerBundle); err != nil {
 		return err
 	}
 
@@ -381,6 +392,30 @@ func testgroup(t *testing.T, groupname string, version string, jobs ...clusterTe
 	)
 	th.Load(addonUpgrades...)
 	th.Load(addonCleanup)
+
+	// Collect kubeaddons controller logs during cleanup.
+	th.Load(testharness.Loadable{
+		Plan: testharness.CleanupPlan,
+		Jobs: testharness.Jobs{func(t *testing.T) error {
+			logFilePath := filepath.Join(dir, "kubeaddons-controller-log.txt")
+			t.Logf("INFO: writing kubeaddons controller logs to %s", logFilePath)
+
+			logFile, err := os.Create(logFilePath)
+			if err != nil {
+				return err
+			}
+			defer logFile.Close()
+
+			logs, err := logsFromPodWithPrefix(tcluster, kubeaddonsControllerNamespace, kubeaddonsControllerPodPrefix)
+			if err != nil {
+				return err
+			}
+			defer logs.Close()
+
+			_, err = io.Copy(logFile, logs)
+			return err
+		}},
+	})
 
 	for _, job := range jobs {
 		th.Load(testharness.Loadable{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

This allows fluentbit to deploy without elasticsearch enabled. If a user
would like to disable elasticsearch and use an alternative log sink,
they would otherwise have to edit the fluentbit addon spec and remove
the dependency.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-70491)
-->
* https://jira.d2iq.com/browse/D2IQ-70491

**Special notes for your reviewer**:

Getting this PR to a reviewable state required some investigation of the kubeaddons controller, so I included a commit that collects its logs during test cleanup. I've also updated Teamcity configuration to collect logs as build artifacts.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[fluentbit] Allows the fluentbit addon to deploy without elasticsearch enabled.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [x] The documentation is updated where needed.
