### PR TITLE
[release/2] chore: move away from old helm/stable repos

### DIFF
--- a/addons/elasticsearch-curator/elasticsearch-curator.yaml
+++ b/addons/elasticsearch-curator/elasticsearch-curator.yaml
@@ -7,9 +7,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: elasticsearch-curator
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "5.8.1-2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "5.8.1-3"
     appversion.kubeaddons.mesosphere.io/elasticsearch-curator: "5.8.1"
-    values.chart.helm.kubeaddons.mesosphere.io/elasticsearch-curator: "https://raw.githubusercontent.com/helm/charts/506eedd/stable/elasticsearch-curator/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/elasticsearch-curator: "https://raw.githubusercontent.com/mesosphere/charts/73fba37/stable/elasticsearch-curator/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -28,7 +28,8 @@ spec:
     - matchLabels:
         kubeaddons.mesosphere.io/name: elasticsearch
   chartReference:
-    chart: stable/elasticsearch-curator
+    chart: elasticsearch-curator
+    repo: https://mesosphere.github.io/charts/stable
     version: 2.2.1
     values: |
       ---

--- a/addons/elasticsearch/elasticsearch.yaml
+++ b/addons/elasticsearch/elasticsearch.yaml
@@ -10,9 +10,9 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.2-7"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.2-8"
     appversion.kubeaddons.mesosphere.io/elasticsearch: "6.8.2"
-    values.chart.helm.kubeaddons.mesosphere.io/elasticsearch: "https://raw.githubusercontent.com/helm/charts/6bfbc8018cd4440637b07c7559d5812e4d9db34d/stable/elasticsearch/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/elasticsearch: "https://raw.githubusercontent.com/mesosphere/charts/73fba37/stable/elasticsearch/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
@@ -28,7 +28,8 @@ spec:
     - name: none
       enabled: true
   chartReference:
-    chart: stable/elasticsearch
+    chart: elasticsearch
+    repo: https://mesosphere.github.io/charts/stable
     version: 1.32.0
     values: |
       ---

--- a/addons/elasticsearchexporter/elasticsearchexporter.yaml
+++ b/addons/elasticsearchexporter/elasticsearchexporter.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: elasticsearchexporter
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-3"
     appversion.kubeaddons.mesosphere.io/elasticsearchexporter: "1.1.0"
-    values.chart.helm.kubeaddons.mesosphere.io/elasticsearchexporter: "https://raw.githubusercontent.com/helm/charts/506eedd/stable/elasticsearch-exporter/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/elasticsearchexporter: "https://raw.githubusercontent.com/mesosphere/charts/73fba37/stable/elasticsearch-exporter/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -27,7 +27,8 @@ spec:
     - matchLabels:
         kubeaddons.mesosphere.io/name: elasticsearch
   chartReference:
-    chart: stable/elasticsearch-exporter
+    chart: elasticsearch-exporter
+    repo: https://mesosphere.github.io/charts/stable
     version: 3.7.0
     values: |
       ---

--- a/addons/external-dns/external-dns.yaml
+++ b/addons/external-dns/external-dns.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: external-dns
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.7.0-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.7.0-2"
     appversion.kubeaddons.mesosphere.io/external-dns: "0.7.0"
-    values.chart.helm.kubeaddons.mesosphere.io/external-dns: "https://raw.githubusercontent.com/helm/charts/b9191a5b526d4988b7938be2049370a1687037a0/stable/external-dns/values-production.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/external-dns: "https://raw.githubusercontent.com/bitnami/charts/9eca03cb2f4b9d4a5b7e877711f810f9151ea2a3/bitnami/external-dns/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -24,7 +24,8 @@ spec:
     - name: none
       enabled: false
   chartReference:
-    chart: stable/external-dns
+    repo: https://charts.bitnami.com/bitnami
+    chart: external-dns
     version: 2.20.4
     values: |
       rbac:

--- a/addons/kibana/kibana.yaml
+++ b/addons/kibana/kibana.yaml
@@ -6,11 +6,11 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kibana
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.10-10"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.10-11"
     appversion.kubeaddons.mesosphere.io/kibana: "6.8.10"
     endpoint.kubeaddons.mesosphere.io/kibana: "/ops/portal/kibana"
     docs.kubeaddons.mesosphere.io/kibana: "https://www.elastic.co/guide/en/kibana/6.8/index.html"
-    values.chart.helm.kubeaddons.mesosphere.io/kibana: "https://raw.githubusercontent.com/helm/charts/506eedd/stable/kibana/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kibana: "https://raw.githubusercontent.com/mesosphere/charts/73fba37/stable/kibana/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -29,7 +29,8 @@ spec:
     - matchLabels:
         kubeaddons.mesosphere.io/name: elasticsearch
   chartReference:
-    chart: stable/kibana
+    chart: kibana
+    repo: https://mesosphere.github.io/charts/stable
     version: 3.2.7
     valuesRemap:
       "ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"

--- a/addons/metallb/metallb.yaml
+++ b/addons/metallb/metallb.yaml
@@ -6,9 +6,9 @@ metadata:
     kubeaddons.mesosphere.io/name: metallb
     kubeaddons.mesosphere.io/provides: loadbalancer
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.9.3-2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.9.3-3"
     appversion.kubeaddons.mesosphere.io/metallb: "0.9.3"
-    values.chart.helm.kubeaddons.mesosphere.io/metallb: "https://raw.githubusercontent.com/helm/charts/76696b9/stable/metallb/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/metallb: "https://raw.githubusercontent.com/mesosphere/charts/73fba37/stable/metallb/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -34,7 +34,8 @@ spec:
             # configure addresses for your network
             addresses: []
   chartReference:
-    chart: stable/metallb
+    chart: metallb
+    repo: https://mesosphere.github.io/charts/stable
     version: 0.12.1
     values: |
       ---

--- a/addons/prometheusadapter/prometheusadapter.yaml
+++ b/addons/prometheusadapter/prometheusadapter.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: prometheusadapter
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "v0.7.0-2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "v0.7.0-3"
     appversion.kubeaddons.mesosphere.io/prometheusadapter: "v0.7.0"
-    values.chart.helm.kubeaddons.mesosphere.io/prometheusadapter: "https://raw.githubusercontent.com/helm/charts/8d6ee06/stable/prometheus-adapter/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/prometheusadapter: "https://raw.githubusercontent.com/prometheus-community/helm-charts/a2b924bf7c439f0531634983dd941eeec2917725/charts/prometheus-adapter/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -27,7 +27,8 @@ spec:
     - matchLabels:
         kubeaddons.mesosphere.io/name: prometheus
   chartReference:
-    chart: stable/prometheus-adapter
+    chart: prometheus-adapter
+    repo: https://prometheus-community.github.io/helm-charts
     version: 2.5.1
     values: |
       ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Backport of some commits needed to make Konvoy 1.5 work again. The helm/stable repo isn't functional, anymore.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
https://jira.d2iq.com/browse/COPS-6748

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix deployment of Addons served from old helm/stable repo.
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
