### PR TITLE
chore: Upgrade istio, kiali, jaeger addons

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,5 +19,7 @@ addons/kibana/* @mesosphere/sig-ksphere-observability @mesosphere/sig-ksphere-ca
 # Networking
 addons/metallb/* @mesosphere/sig-ksphere-networking @mesosphere/sig-ksphere-catalog
 addons/istio/* @mesosphere/sig-ksphere-networking @mesosphere/sig-ksphere-catalog
+addons/kiali/* @mesosphere/sig-ksphere-networking @mesosphere/sig-ksphere-catalog
+addons/jaeger/* @mesosphere/sig-ksphere-networking @mesosphere/sig-ksphere-catalog
 addons/ambassador/* @mesosphere/sig-ksphere-networking @mesosphere/sig-ksphere-catalog
 addons/external-dns/* @mesosphere/sig-ksphere-networking @mesosphere/sig-ksphere-catalog

--- a/addons/istio/istio.yaml
+++ b/addons/istio/istio.yaml
@@ -6,18 +6,10 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: istio
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.12-1"
-    appversion.kubeaddons.mesosphere.io/istio: "1.6.12"
-    appversion.kubeaddons.mesosphere.io/kiali: "1.18.0"
-    appversion.kubeaddons.mesosphere.io/jaeger: "1.16.0"
-    stage.kubeaddons.mesosphere.io/kiali: Preview
-    stage.kubeaddons.mesosphere.io/jaeger: Preview
-    endpoint.kubeaddons.mesosphere.io/kiali: "/ops/portal/kiali"
-    endpoint.kubeaddons.mesosphere.io/jaeger: "/ops/portal/jaeger"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.8.1-1"
+    appversion.kubeaddons.mesosphere.io/istio: "1.8.1"
     docs.kubeaddons.mesosphere.io/istio: "https://istio.io/docs/"
-    docs.kubeaddons.mesosphere.io/kiali: "https://istio.io/docs/tasks/telemetry/kiali/"
-    docs.kubeaddons.mesosphere.io/jaeger: "https://istio.io/docs/tasks/telemetry/distributed-tracing/jaeger/"
-    values.chart.helm.kubeaddons.mesosphere.io/istio: "https://raw.githubusercontent.com/mesosphere/charts/a7d3c02bac8c4c3ae02854e60483b97cfb80b1b7/staging/istio/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/istio: "https://raw.githubusercontent.com/mesosphere/charts/1079b3c/staging/istio/values.yaml"
 spec:
   namespace: istio-system
   requires:
@@ -42,14 +34,9 @@ spec:
   chartReference:
     chart: istio
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.6.12
+    version: 1.8.2
     values: |
       istioOperator:
-        addonComponents:
-          kiali:
-            enabled: true
-          tracing:
-            enabled: true
         components:
           ingressGateways:
           - enabled: true
@@ -61,14 +48,3 @@ spec:
             k8s:
               hpaSpec:
                 minReplicas: 2
-        values:
-          kiali:
-            contextPath: /ops/portal/kiali
-            dashboard:
-              auth:
-                strategy: anonymous
-              grafanaInClusterURL: http://prometheus-kubeaddons-grafana.kubeaddons:3000
-              jaegerInClusterURL: http://tracing/jaeger
-            prometheusAddr: http://prometheus-kubeaddons-prom-prometheus.kubeaddons:9090
-          tracing:
-            contextPath: /ops/portal/jaeger

--- a/addons/jaeger/jaeger.yaml
+++ b/addons/jaeger/jaeger.yaml
@@ -1,0 +1,59 @@
+# ------------------------------------------------------------------------------
+# PREVIEW: this addon is in preview mode and only intended for use in testing environments.
+# ------------------------------------------------------------------------------
+apiVersion: kubeaddons.mesosphere.io/v1beta2
+kind: ClusterAddon
+metadata:
+  name: jaeger
+  labels:
+    kubeaddons.mesosphere.io/name: jaeger
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "2.18.3-1"
+    appversion.kubeaddons.mesosphere.io/jaeger-operator: "1.21.2"
+    appversion.kubeaddons.mesosphere.io/jaeger: "1.21.0"
+    stage.kubeaddons.mesosphere.io/kiali: Preview
+    endpoint.kubeaddons.mesosphere.io/jaeger: "/ops/portal/jaeger"
+    docs.kubeaddons.mesosphere.io/jaeger: "https://www.jaegertracing.io/docs/1.21/"
+    values.chart.helm.kubeaddons.mesosphere.io/jaeger: "https://raw.githubusercontent.com/jaegertracing/helm-charts/aa3b160/charts/jaeger-operator/values.yaml"
+spec:
+  namespace: istio-system
+  kubernetes:
+    minSupportedVersion: v1.19.0
+  cloudProvider:
+    - name: aws
+      enabled: false
+    - name: gcp
+      enabled: false
+    - name: azure
+      enabled: false
+    - name: docker
+      enabled: false
+    - name: vsphere
+      enabled: false
+  chartReference:
+    chart: jaeger-operator
+    repo: https://jaegertracing.github.io/helm-charts/
+    version: 2.18.3
+    values: |
+      image:
+        repository: jaegertracing/jaeger-operator
+        tag: 1.21.2
+
+      jaeger:
+        create: true
+        spec:
+          strategy: allInOne
+          allInOne:
+            image: jaegertracing/all-in-one:1.21.0
+            options:
+              query:
+                base-path: /ops/portal/jaeger
+          ingress:
+            enabled: true
+            annotations:
+              kubernetes.io/ingress.class: "traefik"
+            basePath: /ops/portal/jaeger
+
+      rbac:
+        create: true
+        clusterRole: true

--- a/addons/kiali/kiali.yaml
+++ b/addons/kiali/kiali.yaml
@@ -1,0 +1,72 @@
+# ------------------------------------------------------------------------------
+# PREVIEW: this addon is in preview mode and only intended for use in testing environments.
+# ------------------------------------------------------------------------------
+apiVersion: kubeaddons.mesosphere.io/v1beta2
+kind: ClusterAddon
+metadata:
+  name: kiali
+  labels:
+    kubeaddons.mesosphere.io/name: kiali
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.28.1-1"
+    appversion.kubeaddons.mesosphere.io/kiali-operator: "1.28.1"
+    appversion.kubeaddons.mesosphere.io/kiali: "1.28.1"
+    stage.kubeaddons.mesosphere.io/kiali: Preview
+    endpoint.kubeaddons.mesosphere.io/kiali: "/ops/portal/kiali"
+    docs.kubeaddons.mesosphere.io/kiali: "https://kiali.io/documentation/v1.28/"
+    values.chart.helm.kubeaddons.mesosphere.io/kiali: "https://raw.githubusercontent.com/kiali/helm-charts/850b7287d1bd38efb59674b6c06fe57b7f5796cf/kiali-operator/values.yaml"
+spec:
+  namespace: istio-system
+  kubernetes:
+    minSupportedVersion: v1.19.0
+  cloudProvider:
+    - name: aws
+      enabled: false
+    - name: gcp
+      enabled: false
+    - name: azure
+      enabled: false
+    - name: docker
+      enabled: false
+    - name: vsphere
+      enabled: false
+  chartReference:
+    chart: kiali-operator
+    repo: https://kiali.org/helm-charts/
+    version: 1.28.1
+    values: |
+      image:
+        repo: quay.io/kiali/kiali-operator
+        tag: v1.28.1
+
+      cr:
+        create: true
+        namespace: "istio-system"
+        spec:
+          auth:
+            strategy: anonymous
+          server:
+            web_root: /ops/portal/kiali
+          external_services:
+            grafana:
+              in_cluster_url: http://prometheus-kubeaddons-grafana.kubeaddons:3000
+            prometheus:
+              url: http://prometheus-kubeaddons-prom-prometheus.kubeaddons:9090
+            tracing:
+              in_cluster_url: http://jaeger-kubeaddons-jaeger-operator-jaeger-query:16686
+          deployment:
+            accessible_namespaces:
+            - '**'
+            ingress_enabled: true
+            override_ingress_yaml:
+              metadata:
+                annotations:
+                  kubernetes.io/ingress.class: traefik
+              spec:
+                rules:
+                - http:
+                    paths:
+                    - path:  /ops/portal/kiali
+                      backend:
+                        serviceName: kiali
+                        servicePort: 20001

--- a/metadata/root.yaml
+++ b/metadata/root.yaml
@@ -197,6 +197,28 @@ istio:
       - type: support
         title: Submit a Support Request
         link: https://d2iq.com/services-and-support
+kiali:
+  display_name: kiali
+  description: kiali
+  logo: kiali/logo.svg
+  category: other
+  overview: kiali/overview.md
+  resources:
+    links:
+      - type: support
+        title: Submit a Support Request
+        link: https://d2iq.com/services-and-support
+jaeger:
+  display_name: jaeger
+  description: jaeger
+  logo: jaeger/logo.svg
+  category: other
+  overview: jaeger/overview.md
+  resources:
+    links:
+      - type: support
+        title: Submit a Support Request
+        link: https://d2iq.com/services-and-support
 kibana:
   display_name: kibana
   description: kibana

--- a/metadata/static/jaeger/overview.md
+++ b/metadata/static/jaeger/overview.md
@@ -1,0 +1,3 @@
+# jaeger overview
+
+TODO

--- a/metadata/static/kiali/overview.md
+++ b/metadata/static/kiali/overview.md
@@ -1,0 +1,3 @@
+# kiali overview
+
+TODO

--- a/test/groups.yaml
+++ b/test/groups.yaml
@@ -95,6 +95,8 @@ istio:
     - "cert-manager"
     - "istio"
     - "flagger"
+    - "kiali"
+    - "jaeger"
 
 # ------------------------------------------------------------------------------
 # Local Volume Provisioner


### PR DESCRIPTION
**What type of PR is this?**
Chore

**What this PR does/ why we need it**:
This PR has three commits each for kiali, jaeger and istio. Istio 1.7+ no longer ship kiali and jaeger, therefore, this PR create an independent addons for kiali and jaeger. 

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-73677

**Special notes for your reviewer**:
istio chart upgrade PR https://github.com/mesosphere/charts/pull/929

**Does this PR introduce a user-facing change?**:
yes

```release-note
Istio has been upgraded from 1.6.12 to 1.8.1 
* Kiali and Jaeger are now independent addons and needs to be enabled explicitly
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
