### PR TITLE
Automated chart bump istio-1.8.1

### DIFF
--- a/addons/istio/istio.yaml
+++ b/addons/istio/istio.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: ClusterAddon
 metadata:
@@ -6,8 +5,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: istio
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.12-1"
-    appversion.kubeaddons.mesosphere.io/istio: "1.6.12"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.8.1-1"
+    appversion.kubeaddons.mesosphere.io/istio: "1.8.1"
     appversion.kubeaddons.mesosphere.io/kiali: "1.18.0"
     appversion.kubeaddons.mesosphere.io/jaeger: "1.16.0"
     stage.kubeaddons.mesosphere.io/kiali: Preview
@@ -17,7 +16,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/istio: "https://istio.io/docs/"
     docs.kubeaddons.mesosphere.io/kiali: "https://istio.io/docs/tasks/telemetry/kiali/"
     docs.kubeaddons.mesosphere.io/jaeger: "https://istio.io/docs/tasks/telemetry/distributed-tracing/jaeger/"
-    values.chart.helm.kubeaddons.mesosphere.io/istio: "https://raw.githubusercontent.com/mesosphere/charts/a7d3c02bac8c4c3ae02854e60483b97cfb80b1b7/staging/istio/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/istio: "https://raw.githubusercontent.com/mesosphere/charts/0e4c5b4/staging/istio/values.yaml"
 spec:
   namespace: istio-system
   requires:
@@ -42,7 +41,7 @@ spec:
   chartReference:
     chart: istio
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.6.12
+    version: 1.8.1
     values: |
       istioOperator:
         addonComponents:


### PR DESCRIPTION
**What type of PR is this?**
Chore

**What this PR does/ why we need it**:
Updates Istio chart from 1.6.12 to 1.8.1

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-73677

**Special notes for your reviewer**:
I have tested the chart manually. Here are the test that I did:
1. Tried fresh installation of the chart on a konvoy 1.6 cluster
2. Tried upgrading previous installation of istio with this chart on a konvoy 1.6 cluster. I tried the upgrade from istio 1.6.12 to this version of the chart

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Istio is upgraded from 1.6.12 to 1.8.1
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
