### PR TITLE
[prometheus] upgrade prometheus-operator to version v0.44.x 

### DIFF
--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -42,7 +42,7 @@ spec:
     - name: none
       enabled: true
   chartReference:
-    chart: kube-prometheus-stack
+    chart: prometheus-operator
     repo: https://alejandroesc.github.io/charts-1/staging
     version: 12.11.3
     valuesRemap:
@@ -51,7 +51,6 @@ spec:
       "grafana.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
     values: |
       ---
-      nameOverride: prometheus-operator
       defaultRules:
         rules:
           etcd: false

--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -51,6 +51,7 @@ spec:
       "grafana.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
     values: |
       ---
+      nameOverride: prometheus-operator
       defaultRules:
         rules:
           etcd: false

--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -13,8 +13,8 @@ metadata:
     catalog.kubeaddons.mesosphere.io/addon-revision: "0.44.0-1"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.44.0"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.19.2"
-    appversion.kubeaddons.mesosphere.io/alertmanager: "0.20.0"
-    appversion.kubeaddons.mesosphere.io/grafana: "6.7.3"
+    appversion.kubeaddons.mesosphere.io/alertmanager: "0.21.0"
+    appversion.kubeaddons.mesosphere.io/grafana: "6.1.17"
     endpoint.kubeaddons.mesosphere.io/prometheus: "/ops/portal/prometheus"
     endpoint.kubeaddons.mesosphere.io/alertmanager: "/ops/portal/alertmanager"
     endpoint.kubeaddons.mesosphere.io/grafana: "/ops/portal/grafana"
@@ -25,8 +25,8 @@ metadata:
     # The prometheus-operator chart from prior Konvoy releases can't be upgraded to 8.10.0.
     # See https://github.com/helm/charts/issues/21200.
     # 8.8.5 was the latest version available in mesosphere/charts before it was bumped past 8.10.0.
-    helm.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=8.8.5", "strategy": "delete"}]'
-    helm2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=8.8.5", "strategy": "delete"}]'
+    helm.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=8.8.5", "strategy": "delete"},{"upgradeFrom": "<=9.3.5", "strategy": "delete"}]'
+    helm2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=8.8.5", "strategy": "delete"},{"upgradeFrom": "<=9.3.5", "strategy": "delete"}]'
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6

--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -43,7 +43,7 @@ spec:
       enabled: true
   chartReference:
     chart: prometheus-operator
-    repo: https://alejandroesc.github.io/charts-1/staging
+    repo: https://mesosphere.github.io/charts/staging
     version: 12.11.3
     valuesRemap:
       "prometheus.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"

--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "0.44.0-1"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.44.0"
-    appversion.kubeaddons.mesosphere.io/prometheus: "2.19.2"
+    appversion.kubeaddons.mesosphere.io/prometheus: "2.22.1"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.21.0"
     appversion.kubeaddons.mesosphere.io/grafana: "6.1.17"
     endpoint.kubeaddons.mesosphere.io/prometheus: "/ops/portal/prometheus"

--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -21,7 +21,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/prometheus: "https://prometheus.io/docs/introduction/overview/"
     docs.kubeaddons.mesosphere.io/grafana: "https://grafana.com/docs/"
     docs.kubeaddons.mesosphere.io/alertmanager: "https://prometheus.io/docs/alerting/alertmanager/"
-    values.chart.helm.kubeaddons.mesosphere.io/prometheus: "https://raw.githubusercontent.com/mesosphere/charts/f39e23568cf1a906f4453b1b3a2f5b5f9968eb50/staging/prometheus-operator/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/prometheus: "https://raw.githubusercontent.com/mesosphere/charts/825e9732efe486f372c12015b13db52faa7cfc42/staging/prometheus-operator/values.yaml"
     # The prometheus-operator chart from prior Konvoy releases can't be upgraded to 8.10.0.
     # See https://github.com/helm/charts/issues/21200.
     # 8.8.5 was the latest version available in mesosphere/charts before it was bumped past 8.10.0.
@@ -229,8 +229,6 @@ spec:
                 interval: 30s
                 scheme: http
         prometheusSpec:
-          image:
-            tag: v2.22.1
           thanos:
             version: v0.8.1
           externalLabels:

--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -10,8 +10,8 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.38.1-28"
-    appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.38.1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.44.0-1"
+    appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.44.0"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.19.2"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.20.0"
     appversion.kubeaddons.mesosphere.io/grafana: "6.7.3"
@@ -42,9 +42,9 @@ spec:
     - name: none
       enabled: true
   chartReference:
-    chart: prometheus-operator
-    repo: https://mesosphere.github.io/charts/staging
-    version: 9.3.5
+    chart: kube-prometheus-stack
+    repo: https://alejandroesc.github.io/charts-1/staging
+    version: 12.11.3
     valuesRemap:
       "prometheus.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
       "alertmanager.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"

--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -236,7 +236,7 @@ spec:
           externalLabels:
             cluster: $(CLUSTER_ID)
           containers:
-            - name: prometheus-config-reloader
+            - name: config-reloader
               envFrom:
               - configMapRef:
                   name: cluster-info-configmap

--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -230,7 +230,7 @@ spec:
                 scheme: http
         prometheusSpec:
           image:
-            tag: v2.19.2
+            tag: v2.22.1
           thanos:
             version: v0.8.1
           externalLabels:

--- a/test/addons_test.go
+++ b/test/addons_test.go
@@ -391,6 +391,14 @@ func testgroup(t *testing.T, groupname string, version string, jobs ...clusterTe
 		addonDefaults,
 	)
 	th.Load(addonUpgrades...)
+
+	for _, job := range jobs {
+		th.Load(testharness.Loadable{
+			Plan: testharness.DefaultPlan,
+			Jobs: testharness.Jobs{job(t, tcluster)},
+		})
+	}
+
 	th.Load(addonCleanup)
 
 	// Collect kubeaddons controller logs during cleanup.
@@ -416,13 +424,6 @@ func testgroup(t *testing.T, groupname string, version string, jobs ...clusterTe
 			return err
 		}},
 	})
-
-	for _, job := range jobs {
-		th.Load(testharness.Loadable{
-			Plan: testharness.DefaultPlan,
-			Jobs: testharness.Jobs{job(t, tcluster)},
-		})
-	}
 
 	defer th.Cleanup()
 	th.Validate()

--- a/test/prometheus_test.go
+++ b/test/prometheus_test.go
@@ -73,9 +73,10 @@ func alertmanagerChecker(t *testing.T, cluster testcluster.Cluster) testharness.
 		}
 		defer close(stop)
 
-		// Check alertmanager status is ready.
+		// Alertmanager readiness check
+		// https://prometheus.io/docs/alerting/latest/management_api/#readiness-check
 		var resp *http.Response
-		path := "/api/v2/status"
+		path := "/-/ready"
 		resp, err = http.Get(fmt.Sprintf("http://localhost:%d%s", localport, path))
 		if err != nil {
 			return fmt.Errorf("could not GET %s: %s", path, err)
@@ -83,24 +84,6 @@ func alertmanagerChecker(t *testing.T, cluster testcluster.Cluster) testharness.
 
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("expected GET %s status %d, got %d", path, http.StatusOK, resp.StatusCode)
-		}
-
-		b, err := ioutil.ReadAll(resp.Body)
-		obj := map[string]interface{}{}
-		if err := json.Unmarshal(b, &obj); err != nil {
-			return fmt.Errorf("could not decode JSON response: %s", err)
-		}
-
-		clusterObj, ok := obj["cluster"].(map[string]interface{})
-		if !ok {
-			return fmt.Errorf("JSON response missing key cluster with object value")
-		}
-		status, ok := clusterObj["status"].(string)
-		if !ok {
-			return fmt.Errorf("cluster missing key status with string value")
-		}
-		if status != "ready" {
-			return fmt.Errorf("expected status ready, got %s", status)
 		}
 
 		t.Logf("INFO: successfully tested alertmanager")

--- a/test/prometheus_test.go
+++ b/test/prometheus_test.go
@@ -25,7 +25,7 @@ const (
 
 func promChecker(t *testing.T, cluster testcluster.Cluster) testharness.Job {
 	return func(t *testing.T) error {
-		time.Sleep(time.Second * 120)
+		time.Sleep(time.Second * 240)
 		localport, stop, err := portForwardPodWithPrefix(cluster, "kubeaddons", promPodPrefix, promPort)
 		if err != nil {
 			return fmt.Errorf("could not forward port to prometheus pod: %w", err)

--- a/test/prometheus_test.go
+++ b/test/prometheus_test.go
@@ -25,7 +25,8 @@ const (
 
 func promChecker(t *testing.T, cluster testcluster.Cluster) testharness.Job {
 	return func(t *testing.T) error {
-		time.Sleep(time.Second * 240)
+		time.Sleep(time.Minute * 5)
+		t.Logf("INFO: starting to test prometheus")
 		localport, stop, err := portForwardPodWithPrefix(cluster, "kubeaddons", promPodPrefix, promPort)
 		if err != nil {
 			return fmt.Errorf("could not forward port to prometheus pod: %w", err)
@@ -65,6 +66,7 @@ func promChecker(t *testing.T, cluster testcluster.Cluster) testharness.Job {
 
 func alertmanagerChecker(t *testing.T, cluster testcluster.Cluster) testharness.Job {
 	return func(t *testing.T) error {
+		t.Logf("INFO: starting to test alertmanager")
 		localport, stop, err := portForwardPodWithPrefix(cluster, "kubeaddons", alertmanagerPodPrefix, alertmanagerPort)
 		if err != nil {
 			return fmt.Errorf("could not forward port to alertmanager pod: %s", err)
@@ -108,6 +110,7 @@ func alertmanagerChecker(t *testing.T, cluster testcluster.Cluster) testharness.
 
 func grafanaChecker(t *testing.T, cluster testcluster.Cluster) testharness.Job {
 	return func(t *testing.T) error {
+		t.Logf("INFO: starting to test grafana")
 		localport, stop, err := portForwardPodWithPrefix(cluster, "kubeaddons", grafanaPodPrefix, grafanaPort)
 		if err != nil {
 			return fmt.Errorf("could not forward port to grafana pod: %s", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
https://jira.d2iq.com/browse/D2IQ-73462
https://jira.d2iq.com/browse/D2IQ-73540

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Makes changes to allow upgrade of prometheus operator

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Prometheus-operator upgraded to v0.44.x
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
