### PR TITLE
Disabled the nvidia driver container by default

### DIFF
--- a/addons/nvidia/nvidia.yaml
+++ b/addons/nvidia/nvidia.yaml
@@ -8,7 +8,7 @@ metadata:
     kubeaddons.mesosphere.io/name: nvidia
     kubeaddons.mesosphere.io/provides: nvidia
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.2.0-7"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.2.0-8"
     appversion.kubeaddons.mesosphere.io/nvidia: "0.2.0"
     values.chart.helm.kubeaddons.mesosphere.io/nvidia: "https://raw.githubusercontent.com/mesosphere/charts/master/staging/nvidia/values.yaml"
     # The nvidia addon requires its underlying driver to be completely removed before adding an upgraded one, as two versions of the driver can no cleanly
@@ -39,10 +39,6 @@ spec:
         enabled: true
         nodeSelector:
           konvoy.mesosphere.com/gpu-provider: NVIDIA
-        initContainers:
-        - name: init-wait
-          image: busybox
-          command: ['sh', '-c', 'sleep 200']
       nvidia-device-plugin:
         enabled: true
         image:
@@ -56,12 +52,8 @@ spec:
              memory: 128Mi
         nodeSelector:
           konvoy.mesosphere.com/gpu-provider: NVIDIA
-        initContainers:
-        - name: init-wait
-          image: busybox
-          command: ['sh', '-c', 'sleep 180']
       nvidia-driver:
-        enabled: true
+        enabled: false
         image:
           tag: "418.87.01-centos7"
         resources:


### PR DESCRIPTION
Disabled the driver container in favor of the host driver support

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
Chore - Support host Nvidia driver by default in Konvoy 1.7

**What this PR does/ why we need it**:
Support upgradable Nvidia addon and reply on Nvidia driver running on the host by default.

**Which issue(s) this PR fixes**:
[D2IQ-73307](https://jira.d2iq.com/browse/D2IQ-73307)

**Special notes for your reviewer**:
Please see https://github.com/mesosphere/konvoy/pull/2725 for testing steps.

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Starting from Konvoy 1.7, Nvidia GPU driver has to be running on the host system by default. Please see [Konvoy GPU docs](https://docs.d2iq.com/dkp/konvoy/1.7/gpu/) for details.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
