### PR TITLE
[Velero] update to v1.5.2 and minio 8.0.8

### DIFF
--- a/addons/velero/velero.yaml
+++ b/addons/velero/velero.yaml
@@ -31,8 +31,11 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.1-8"
-    values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/mesosphere/charts/51eb074b28fd5a8e5299d0041ce4ed38122e20d7/staging/velero/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.2-1"
+    values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/mesosphere/charts/24860fab46d50bd1c8251bc0b70370cef3bec61d/staging/velero/values.yaml"
+    # minio StatefulSet changes too much to be updated
+    helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=3.0.6\", \"strategy\": \"delete\"}]"
+    helm2.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=3.0.6\", \"strategy\": \"delete\"}]"
 spec:
   namespace: velero
   kubernetes:
@@ -54,54 +57,58 @@ spec:
   chartReference:
     chart: velero
     repo: https://mesosphere.github.io/charts/staging
-    version: 3.0.6
+    version: 3.1.0
     values: |
       ---
+      enableHelmHooks: false # handle helm install --atomic through kubeaddons
       configuration:
         provider: "aws"
         backupStorageLocation:
-          name: "aws"
           bucket: "velero"
           config:
-            region: "fallback"     # enables non-production fallback minio backend
-            s3ForcePathStyle: true # allows usage of fallback backend
+            region: "fallback" # enables non-production fallback minio backend, detected by kubeaddons-addon-initializer
             s3Url: http://minio.velero.svc:9000
+            s3ForcePathStyle: true
+            insecureSkipTLSVerify: "true"
         volumeSnapshotLocation:
-          name: "aws"
           config:
             region: "fallback"
       credentials:
+        name: velero-kubeaddons
         secretContents:
           cloud: "placeholder"
       schedules:
         default:
           schedule: "0 0 * * *"
+          template:
+            ttl: 720h # 30 day retention, required to create schedule
       metrics:
         enabled: true
         service:
           labels:
             servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
       initContainers:
-      - name: initialize-velero
-        image: mesosphere/kubeaddons-addon-initializer:v0.4.3
-        args: ["velero"]
-        env:
-        - name: "VELERO_MINIO_FALLBACK_SECRET_NAME"
-          value: "velero-kubeaddons"
+        - name: initialize-velero
+          image: mesosphere/kubeaddons-addon-initializer:v0.4.4
+          args: ["velero"]
+          env:
+            - name: "VELERO_MINIO_FALLBACK_SECRET_NAME"
+              value: "velero-kubeaddons"
+        - name: velero-plugin-for-aws
+          image: velero/velero-plugin-for-aws:v1.1.0
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /target
+              name: plugins
       minioBackend: true
       minio:
         mode: distributed
-        extraArgs:
-          - --json
         defaultBucket:
           enabled: true
           name: velero
         bucketRoot: "/data"
         mountPath: "/data"
         existingSecret: minio-creds-secret
-        livenessProbe:
-          initialDelaySeconds: 120
-          periodSeconds: 20
         resources:
           requests:
             memory: 256Mi
@@ -110,13 +117,11 @@ spec:
             memory: 512Mi
             cpu: 750m
         persistence:
-          volumeTemplatePrefix: data
-        statefulSetNameOverride: minio
-        statefulSetForceCleanup: true
+          size: 10Gi # match default of old minio version
         ingress:
           enabled: true
           hosts:
-          - ""
+            - ""
           annotations:
             kubernetes.io/ingress.class: traefik
             traefik.ingress.kubernetes.io/frontend-entry-points: velero-minio


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature, update minio and velero. See https://github.com/mesosphere/charts/pull/937 for more details.

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
https://jira.d2iq.com/browse/D2IQ-73500


**Special notes for your reviewer**:
currently points to my chart: https://github.com/s12chung/mycharts
which is currently at: https://github.com/mesosphere/charts/pull/937.

Already tested on Konvoy 1.7 cluster.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Upgrade Velero to 1.5.2 and minio 8.0.8. Users can now use the official velero client, where before users needed to use a patched velero client.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [x] The documentation is updated where needed.
