### PR TITLE
Automated chart bump istio-1.8.4

### DIFF
--- a/addons/istio/istio.yaml
+++ b/addons/istio/istio.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: istio
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.8.1-2"
-    appversion.kubeaddons.mesosphere.io/istio: "1.8.1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.8.2-1"
+    appversion.kubeaddons.mesosphere.io/istio: "1.8.2"
     docs.kubeaddons.mesosphere.io/istio: "https://istio.io/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/istio: "https://raw.githubusercontent.com/mesosphere/charts/f2ee8a0/staging/istio/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/istio: "https://raw.githubusercontent.com/mesosphere/charts/2a68b97/staging/istio/values.yaml"
 spec:
   namespace: istio-system
   requires:
@@ -35,7 +35,7 @@ spec:
   chartReference:
     chart: istio
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.8.3
+    version: 1.8.4
     values: |
       istioOperator:
         components:

--- a/addons/istio/istio.yaml
+++ b/addons/istio/istio.yaml
@@ -15,8 +15,6 @@ spec:
     - matchLabels:
         kubeaddons.mesosphere.io/name: cert-manager
         kubeaddons.mesosphere.io/cert-manager: v1
-    - matchLabels:
-        kubeaddons.mesosphere.io/name: prometheus
   kubernetes:
     minSupportedVersion: v1.16.0
   cloudProvider:


### PR DESCRIPTION
**What type of PR is this?**
Chore 

**What this PR does/ why we need it**:
Bump istio from 1.8.1 to 1.8.2

**Which issue(s) this PR fixes**:
https://github.com/istio/istio/issues/29566

**Special notes for your reviewer**:
This PR brings a fix for the issue that blocks Kaptain from running on istio-1.8.1

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
