### PR TITLE
Automated chart bump gatekeeper-0.5.1

### DIFF
--- a/addons/gatekeeper/gatekeeper.yaml
+++ b/addons/gatekeeper/gatekeeper.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: Addon
 metadata:
@@ -7,10 +6,10 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: gatekeeper
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "3.0.4-4"
-    appversion.kubeaddons.mesosphere.io/gatekeeper: "3.0.4-beta.1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "3.2.2-1"
+    appversion.kubeaddons.mesosphere.io/gatekeeper: "3.2.2"
     docs.kubeaddons.mesosphere.io/gatekeeper: "https://github.com/open-policy-agent/gatekeeper/blob/master/README.md"
-    values.chart.helm.kubeaddons.mesosphere.io/gatekeeper: "https://raw.githubusercontent.com/mesosphere/charts/f52ab9415b53aee946ff8e55a60b50be193b7ea7/staging/gatekeeper/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/gatekeeper: "https://raw.githubusercontent.com/mesosphere/charts/36cf0da/staging/gatekeeper/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -34,15 +33,13 @@ spec:
   chartReference:
     chart: gatekeeper
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.4.2
+    version: 0.5.1
     values: |
       ---
+      replicas: 2
       image:
-        tag: v3.0.4-beta.1
-      resources:
-        limits:
-          cpu: 500m
-          memory: 500Mi
-        requests:
-          cpu: 200m
-          memory: 300Mi
+        repository: openpolicyagent/gatekeeper
+        release: v3.2.2
+      webhook:
+        certManager:
+          enabled: true


### PR DESCRIPTION
**What type of PR is this?**
Chore

**What this PR does/ why we need it**:
upgrade gatekeeper addon to newer version

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-73506

**Special notes for your reviewer**:
The upstream chart is located at https://github.com/open-policy-agent/gatekeeper/tree/master/charts/gatekeeper

I have done the manual upgrade test. Here are the steps that I followed:
```
1. Provisioned a Konvoy 1.6 cluster with gatekeeper enabled
2. Created a gatekeeper policy to validate allowed repository that a pod can use
     ( Here is the configuration that I used to test https://github.com/arbhoj/gatekeeper-policies/tree/master/allowed-repos-deployment-example)
3. Validated that the policy is working 
4. Upgraded gatekeeper using this chart
5. Validated that the policy is still working
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
