### PR TITLE
[ElasticSearch/Kibana] chore: bump versions of kibana/es to 6.18.13

### DIFF
--- a/addons/elasticsearch/elasticsearch.yaml
+++ b/addons/elasticsearch/elasticsearch.yaml
@@ -10,8 +10,8 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.2-10"
-    appversion.kubeaddons.mesosphere.io/elasticsearch: "6.8.2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.13-11"
+    appversion.kubeaddons.mesosphere.io/elasticsearch: "6.8.13"
     values.chart.helm.kubeaddons.mesosphere.io/elasticsearch: "https://raw.githubusercontent.com/mesosphere/charts/73fba37/stable/elasticsearch/values.yaml"
     # Some StatefulSet changes can't be applied, so we need to delete and recreate.
     helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=6.8.2\", \"strategy\": \"delete\"}]"
@@ -38,6 +38,14 @@ spec:
     version: 1.32.0
     values: |
       ---
+      # Default values for elasticsearch.
+      # This is a YAML-formatted file.
+      # Declare variables to be passed into your templates.
+      appVersion: "6.8.13"
+
+      image:
+        tag: "6.8.13"
+
       cluster:
         config:
           # Disable automatic creation of audit log indexes.

--- a/addons/kibana/kibana.yaml
+++ b/addons/kibana/kibana.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kibana
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.10-12"
-    appversion.kubeaddons.mesosphere.io/kibana: "6.8.10"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.13-13"
+    appversion.kubeaddons.mesosphere.io/kibana: "6.8.13"
     endpoint.kubeaddons.mesosphere.io/kibana: "/ops/portal/kibana"
     docs.kubeaddons.mesosphere.io/kibana: "https://www.elastic.co/guide/en/kibana/6.8/index.html"
     values.chart.helm.kubeaddons.mesosphere.io/kibana: "https://raw.githubusercontent.com/mesosphere/charts/73fba37/stable/kibana/values.yaml"
@@ -39,7 +39,7 @@ spec:
     values: |
       ---
       image:
-        tag: 6.8.10
+        tag: 6.8.13
       files:
         kibana.yml:
           ## Default Kibana configuration from kibana-docker.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
N/A 
**Special notes for your reviewer**:
CVE issue is what motivated this

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Elasticsearch and Kibana bumpbed to versions 6.8.13
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
