### PR TITLE
kibana: Downgrade to 6.8.10 to fix regression

### DIFF
--- a/addons/elasticsearch/elasticsearch.yaml
+++ b/addons/elasticsearch/elasticsearch.yaml
@@ -10,8 +10,8 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.13-11"
-    appversion.kubeaddons.mesosphere.io/elasticsearch: "6.8.13"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.13-12"
+    appversion.kubeaddons.mesosphere.io/elasticsearch: "6.8.10"
     values.chart.helm.kubeaddons.mesosphere.io/elasticsearch: "https://raw.githubusercontent.com/mesosphere/charts/73fba37/stable/elasticsearch/values.yaml"
     # Some StatefulSet changes can't be applied, so we need to delete and recreate.
     helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=6.8.2\", \"strategy\": \"delete\"}]"
@@ -41,10 +41,10 @@ spec:
       # Default values for elasticsearch.
       # This is a YAML-formatted file.
       # Declare variables to be passed into your templates.
-      appVersion: "6.8.13"
+      appVersion: "6.8.10"
 
       image:
-        tag: "6.8.13"
+        tag: "6.8.10"
 
       cluster:
         config:

--- a/addons/kibana/kibana.yaml
+++ b/addons/kibana/kibana.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kibana
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.10-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.13-14"
     appversion.kubeaddons.mesosphere.io/kibana: "6.8.10"
     endpoint.kubeaddons.mesosphere.io/kibana: "/ops/portal/kibana"
     docs.kubeaddons.mesosphere.io/kibana: "https://www.elastic.co/guide/en/kibana/6.8/index.html"

--- a/addons/kibana/kibana.yaml
+++ b/addons/kibana/kibana.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kibana
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.13-13"
-    appversion.kubeaddons.mesosphere.io/kibana: "6.8.13"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.10-1"
+    appversion.kubeaddons.mesosphere.io/kibana: "6.8.10"
     endpoint.kubeaddons.mesosphere.io/kibana: "/ops/portal/kibana"
     docs.kubeaddons.mesosphere.io/kibana: "https://www.elastic.co/guide/en/kibana/6.8/index.html"
     values.chart.helm.kubeaddons.mesosphere.io/kibana: "https://raw.githubusercontent.com/mesosphere/charts/73fba37/stable/kibana/values.yaml"
@@ -39,7 +39,7 @@ spec:
     values: |
       ---
       image:
-        tag: 6.8.13
+        tag: 6.8.10
       files:
         kibana.yml:
           ## Default Kibana configuration from kibana-docker.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
downgrade to 6.8.10 to fix regression - metrics were not getting exported

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
https://jira.d2iq.com/browse/D2IQ-73949

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: Downgrade kibana and elasticsearch to 6.8.10 to fix a regression
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
