### PR TITLE
fix: addons test for release branches

### DIFF
--- a/test/addons_test.go
+++ b/test/addons_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -44,6 +45,8 @@ const (
 	comRepoRef    = "master"
 	comRepoRemote = "origin"
 
+	defaultKBARepoRef = "master"
+
 	allAWSGroupName = "allAWS"
 
 	tempDir = "/tmp/kubernetes-base-addons"
@@ -60,15 +63,26 @@ const (
 )
 
 var (
-	cat       catalog.Catalog
-	localRepo repositories.Repository
-	comRepo   repositories.Repository
-	groups    map[string][]v1beta2.AddonInterface
+	cat        catalog.Catalog
+	localRepo  repositories.Repository
+	comRepo    repositories.Repository
+	kbaRepoRef string
+	groups     map[string][]v1beta2.AddonInterface
 )
 
 type clusterTestJob func(*testing.T, testcluster.Cluster) testharness.Job
 
-func init() {
+var kbaBranchFlag = flag.String("kba-branch", "", "")
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	if *kbaBranchFlag != "" {
+		kbaRepoRef = *kbaBranchFlag
+	} else {
+		kbaRepoRef = defaultKBARepoRef
+	}
+
 	var err error
 
 	fmt.Println("initializing local repository for test...")
@@ -99,6 +113,8 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+
+	os.Exit(m.Run())
 }
 
 func getGroupsMapFromFile(f string) (testgroups.Groups, error) {
@@ -563,7 +579,7 @@ func testGroupUpgrades(t *testing.T, groupname string, version string, jobs []cl
 	addonUpgrades := testharness.Loadables{}
 	for _, newAddon := range addons {
 		t.Logf("verifying whether upgrade testing is needed for addon %s", newAddon.GetName())
-		oldAddon, err := addontesters.GetLatestAddonRevisionFromLocalRepoBranch("../", comRepoRemote, comRepoRef, newAddon.GetName())
+		oldAddon, err := addontesters.GetLatestAddonRevisionFromLocalRepoBranch("../", comRepoRemote, kbaRepoRef, newAddon.GetName())
 		if err != nil {
 			if strings.Contains(err.Error(), "directory not found") {
 				t.Logf("no need to upgrade test %s, it appears to be a new addon (no previous revisions found in branch %s)", newAddon.GetName(), comRepoRef)

--- a/test/scripts/test-wrapper.go
+++ b/test/scripts/test-wrapper.go
@@ -36,6 +36,7 @@ func main() {
 	if len(os.Args) > 2 {
 		upstreamBranch = os.Args[2]
 	}
+
 	modifiedAddons, err := getModifiedAddons(upstreamRemote, upstreamBranch)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
The addons tests assumed they were always run with `master` being the
target branch. However, during release, we often target different
branches (e.g. release/3.2). Therefore, the tests need to be
configurable.

Now, the tests can be configured with a command-line flag:

```
go test -tags experimental -timeout 60m -race -v -run TestPrometheusGroup -kba-branch release/3.2
```

This would run the prometheus test group tests against the release/3.2
branch.

If the flag is not provided then `master` is assumed to be the target
branch so the default behaviour doesn't change.

After this commit has been merged, we need to do 2 things:

1. backport to release/3.2 branch
2. change step 2 of this build configuration to pass the target branch
   to the tests:
   https://teamcity.mesosphere.io/admin/editBuildRunners.html?id=buildType:kubeaddons_KubernetesBaseAddons

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
