### PR TITLE
[3.2] fix: addons test for release branches

### DIFF
--- a/test/scripts/test-wrapper.go
+++ b/test/scripts/test-wrapper.go
@@ -36,6 +36,7 @@ func main() {
 	if len(os.Args) > 2 {
 		upstreamBranch = os.Args[2]
 	}
+
 	modifiedAddons, err := getModifiedAddons(upstreamRemote, upstreamBranch)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
backport of #856 


**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
The addons tests assumed they were always run with `master` being the
target branch. However, during release, we often target different
branches (e.g. release/3.2). Therefore, the tests need to be
configurable.

Now, the tests can be configured with a command-line flag:

```
go test -tags experimental -timeout 60m -race -v -run TestPrometheusGroup -kba-branch release/3.2
```

This would run the prometheus test group tests against the release/3.2
branch.

If the flag is not provided then `master` is assumed to be the target
branch so the default behaviour doesn't change.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
