### PR TITLE
Automated chart bump defaultstorageclass-0.0.6

### DIFF
--- a/addons/defaultstorageclass-protection/defaultstorageclass-protection.yaml
+++ b/addons/defaultstorageclass-protection/defaultstorageclass-protection.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: ClusterAddon
 metadata:
@@ -6,7 +5,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: defaultstorageclass-protection
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.0.5-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.0.5-2"
     appversion.kubeaddons.mesosphere.io/defaultstorageclass-protection: "0.0.5"
     # version 0.0.5 changed the selectors
     helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<0.0.5\", \"strategy\": \"delete\"}]"
@@ -33,7 +32,7 @@ spec:
   chartReference:
     chart: defaultstorageclass
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.0.5
+    version: 0.0.6
     values: |
       ---
       issuer:


### PR DESCRIPTION
Add release note or "none":
```release-note
- update client-go to 0.19.2 to support k8s 1.16-1.21
- use the distroless image and run as nonroot user to address image CVEs
```