### PR TITLE
fix: prometheusadapter reporting double CPU and memory

### DIFF
--- a/addons/prometheusadapter/prometheusadapter.yaml
+++ b/addons/prometheusadapter/prometheusadapter.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: prometheusadapter
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "v0.8.3-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "v0.8.3-2"
     appversion.kubeaddons.mesosphere.io/prometheusadapter: "v0.8.3"
     values.chart.helm.kubeaddons.mesosphere.io/prometheusadapter: "https://raw.githubusercontent.com/prometheus-community/helm-charts/61fb05e4f4ba9b6e4255a07338715414a3f493a0/charts/prometheus-adapter/values.yaml"
 spec:
@@ -47,7 +47,7 @@ spec:
       rules:
         resource:
           cpu:
-            containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[2m])) by (<<.GroupBy>>)
+            containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!='POD',container!='',pod!=''}[2m])) by (<<.GroupBy>>)
             nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[2m])) by (<<.GroupBy>>)
             resources:
               overrides:
@@ -59,7 +59,7 @@ spec:
                  resource: pod
             containerLabel: container
           memory:
-            containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+            containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,container!='POD',container!='',pod!=''}) by (<<.GroupBy>>)
             nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
             resources:
               overrides:


### PR DESCRIPTION
Signed-off-by: Dimitri Koshkin <dimitri.koshkin@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Issue was fixed in a upstream chart in https://github.com/kubernetes-sigs/prometheus-adapter/issues/211
Something to note is that `container_name` did not work in my testing, it was instead just `container`.

After applying these changes note there is now only 1 container
```
kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespaces/default/pods/cpu-stress | jq
{
  "kind": "PodMetrics",
  "apiVersion": "metrics.k8s.io/v1beta1",
  "metadata": {
    "name": "cpu-stress",
    "namespace": "default",
    "creationTimestamp": "2021-02-08T23:55:13Z"
  },
  "timestamp": "2021-02-08T23:55:13Z",
  "window": "1m0s",
  "containers": [
    {
      "name": "cpu-stress",
      "usage": {
        "cpu": "1",
        "memory": "828Ki"
      }
    }
  ]
}
```
```
kubectl top pods
NAME         CPU(cores)   MEMORY(bytes)
cpu-stress   1000m        0Mi
```

The changes are also correctly reflected in the Kubernetes dashboard, notice around 15:51 the resources were halved.  
![image](https://user-images.githubusercontent.com/4969231/107300545-9a052380-6a2e-11eb-83d1-933eed4c1911.png)




**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (COPS-6801)
* https://jira.d2iq.com/browse/COPS-6801
-->
https://jira.d2iq.com/browse/COPS-6801

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
prometheusadapter: fix an error were resources in reported by the Kubernetes dashboard and `kubectl top` reported double of the actual resources.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
