### PR TITLE
kiali: set version for kiali/kiali image

### DIFF
--- a/addons/kiali/kiali.yaml
+++ b/addons/kiali/kiali.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kiali
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.29.0-2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.29.0-3"
     appversion.kubeaddons.mesosphere.io/kiali-operator: "1.29.0"
     appversion.kubeaddons.mesosphere.io/kiali: "1.29.0"
     stage.kubeaddons.mesosphere.io/kiali: Experimental
@@ -57,6 +57,8 @@ spec:
             tracing:
               in_cluster_url: http://jaeger-kubeaddons-jaeger-operator-jaeger-query:16686
           deployment:
+            image_version: v1.29.0
+            version_label: v1.29.0
             accessible_namespaces:
             - '**'
             ingress_enabled: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Set the version fields so that the kiali operator doesn't just pull in the latest version.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kiali: configure to use the same version for `kiali/kialii` that matches the operator.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
