### PR TITLE
[release/3.0] Bump prometheus to 9.3.7

### DIFF
--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -10,7 +10,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.38.1-22"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.38.1-23"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.38.1"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.19.2"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.20.0"
@@ -21,7 +21,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/prometheus: "https://prometheus.io/docs/introduction/overview/"
     docs.kubeaddons.mesosphere.io/grafana: "https://grafana.com/docs/"
     docs.kubeaddons.mesosphere.io/alertmanager: "https://prometheus.io/docs/alerting/alertmanager/"
-    values.chart.helm.kubeaddons.mesosphere.io/prometheus: "https://raw.githubusercontent.com/mesosphere/charts/d1c73bd0d/staging/prometheus-operator/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/prometheus: "https://raw.githubusercontent.com/mesosphere/charts/8c9ba776207eb531410bb3db53890c28500c365b/staging/prometheus-operator/values.yaml"
     # The prometheus-operator chart from prior Konvoy releases can't be upgraded to 8.10.0.
     # See https://github.com/helm/charts/issues/21200.
     # 8.8.5 was the latest version available in mesosphere/charts before it was bumped past 8.10.0.
@@ -44,7 +44,7 @@ spec:
   chartReference:
     chart: prometheus-operator
     repo: https://mesosphere.github.io/charts/staging
-    version: 9.3.3
+    version: 9.3.7
     valuesRemap:
       "prometheus.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
       "alertmanager.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Backports https://github.com/mesosphere/kubernetes-base-addons/pull/868 for konvoy 1.5 patch release
Looks like this bump includes a couple of versions.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
https://jira.d2iq.com/browse/D2IQ-74181
https://jira.d2iq.com/browse/COPS-6807

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: Disables AggregatedAPIDown rule for k8s <1.18 (regression)
fix: Bump k8s-sidecar to 1.3.0 to align and fix CVEs
fix: Use newer image for jq to mitigate CVE
fix: Use kubectl 1.19.7 to mitigate CVE
fix: Adds a missing service account which caused addon deletion/cleanup to fail occasionally
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
