### PR TITLE
[auto-bump][chart] reloader-v0.0.81

### DIFF
--- a/addons/reloader/reloader.yaml
+++ b/addons/reloader/reloader.yaml
@@ -6,16 +6,16 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: reloader
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "v0.0.80-1"
-    appversion.kubeaddons.mesosphere.io/reloader: "v0.0.80"
-    values.chart.helm.kubeaddons.mesosphere.io/reloader: https://raw.githubusercontent.com/stakater/Reloader/dc3494c/deployments/kubernetes/chart/reloader/values.yaml
+    catalog.kubeaddons.mesosphere.io/addon-revision: "v0.0.81-1"
+    appversion.kubeaddons.mesosphere.io/reloader: "v0.0.81"
+    values.chart.helm.kubeaddons.mesosphere.io/reloader: https://raw.githubusercontent.com/stakater/Reloader/4f551ad/deployments/kubernetes/chart/reloader/values.yaml
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
   chartReference:
     chart: reloader
     repo: https://stakater.github.io/stakater-charts
-    version: v0.0.80
+    version: v0.0.81
     values: |
       ---
       reloader:


### PR DESCRIPTION
        ##### Add Release Notes or "None":

```release-note
NONE
```
        This is automated bump triggered from the source repo containing the updated Chart/Addon.
        