### PR TITLE
[gatekeeper] chore: allow gatekeeper proxy to use namespace selector

### DIFF
--- a/addons/gatekeeper/gatekeeper.yaml
+++ b/addons/gatekeeper/gatekeeper.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: gatekeeper
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "3.3.0-3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "3.3.0-4"
     appversion.kubeaddons.mesosphere.io/gatekeeper: "3.3.0"
     docs.kubeaddons.mesosphere.io/gatekeeper: "https://github.com/open-policy-agent/gatekeeper/blob/master/README.md"
     values.chart.helm.kubeaddons.mesosphere.io/gatekeeper: "https://raw.githubusercontent.com/mesosphere/charts/a8fafc2/staging/gatekeeper/values.yaml"
@@ -33,11 +33,12 @@ spec:
   chartReference:
     chart: gatekeeper
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.6.2
+    version: 0.6.3
     valuesRemap:
       "mutations.enable": "gatekeeper.mutation.enable"
       "mutations.enablePodProxy": "gatekeeper.mutation.enablePodProxy"
       "mutations.excludeNamespacesFromProxy": "gatekeeper.mutation.excludeNamespacesFromProxy"
+      "mutations.namespaceSelectorForProxy": "gatekeeper.mutation.namespaceSelectorForProxy"
       "proxySettings.noProxy": "gatekeeper.no-proxy"
       "proxySettings.httpProxy": "gatekeeper.http-proxy"
       "proxySettings.httpsProxy": "gatekeeper.https-proxy"
@@ -62,3 +63,4 @@ spec:
         enable: false
         enablePodProxy: false
         excludeNamespacesFromProxy: []
+        namespaceSelectorForProxy: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This allows us to create namespace selectors to negotiate which namespaces will get proxy settings mutated on their pods.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
