### PR TITLE
[release/3][BACKPORT] Prometheus: Enable etcd rules

### DIFF
--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -58,14 +58,6 @@ spec:
           # addon alert rules are defaulted to false to prevent potential misfires if addons
           # are disabled.
           velero: false
-        homeDashboard:
-          cronJob:
-            image: apteno/alpine-jq:2021-01-19
-        hooks:
-          grafana:
-            image: apteno/alpine-jq:2021-01-19
-          prometheus:
-            kubectlImage: bitnami/kubectl:1.19.7
       prometheus:
         ingress:
           enabled: true

--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -9,7 +9,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.44.0-6"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.44.0-7"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.44.0"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.22.1"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.21.0"
@@ -52,13 +52,9 @@ spec:
       "grafana.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
     values: |
       ---
-      defaultRules:
-        rules:
-          etcd: false
       mesosphereResources:
         create: true
         rules:
-          etcd: true
           # addon alert rules are defaulted to false to prevent potential misfires if addons
           # are disabled.
           velero: false


### PR DESCRIPTION
This is a backport of the following PR:

https://github.com/mesosphere/kubernetes-base-addons/pull/938



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
When I removed mesosphere-specific etcd rules to use the default, I didn't realize the config here needed to be updated to reflect those changes. I tested adding the rule to the daily cluster and verified all the rules look good.
![image](https://user-images.githubusercontent.com/5897740/109857944-12b36600-7c10-11eb-8a1a-a4ee587df3ff.png)
The change was made in v9.3.4, so we need to backport this to konvoy 1.7/1.6/1.5 (release/3.3, release/3.0, release/2.5)

Also, removed some unnecessary configs that have since been added to the chart values as default (https://github.com/mesosphere/charts/pull/969, https://github.com/mesosphere/charts/pull/962/files#diff-4eefbe60d75fc0250847e2e4dfd675f9977d572e6f0b5615b552b8223719a6caR2324)

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
prometheus(fix): Re-enable etcd prometheus rules
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
