### PR TITLE
[auto-bump][chart] kube-oidc-proxy-0.2.4

### DIFF
--- a/addons/kube-oidc-proxy/kube-oidc-proxy.yaml
+++ b/addons/kube-oidc-proxy/kube-oidc-proxy.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: Addon
 metadata:
@@ -7,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kube-oidc-proxy
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.2.0-2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.2.0-3"
     appversion.kubeaddons.mesosphere.io/kube-oidc-proxy: "v0.2.0"
-    values.chart.helm.kubeaddons.mesosphere.io/kube-oidc-proxy: "https://raw.githubusercontent.com/mesosphere/charts/8f43d8c479a61863c34fdfdb5ae56b9e3f81bbce/staging/kube-oidc-proxy/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kube-oidc-proxy: "https://raw.githubusercontent.com/mesosphere/charts/b9bce4c/staging/kube-oidc-proxy/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -37,7 +36,7 @@ spec:
   chartReference:
     chart: kube-oidc-proxy
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.2.3
+    version: 0.2.4
     values: |
       ---
       image:


### PR DESCRIPTION

        ##### Add Release Notes or "None":

        ```release-note

        ```
        This is automated bump triggered from the source repo containing the updated Chart/Addon.
        