### PR TITLE
Upgrade kibana to 6.8.15

### DIFF
--- a/addons/kibana/kibana.yaml
+++ b/addons/kibana/kibana.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kibana
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.13-15"
-    appversion.kubeaddons.mesosphere.io/kibana: "6.8.10"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "6.8.15-1"
+    appversion.kubeaddons.mesosphere.io/kibana: "6.8.15"
     endpoint.kubeaddons.mesosphere.io/kibana: "/ops/portal/kibana"
     docs.kubeaddons.mesosphere.io/kibana: "https://www.elastic.co/guide/en/kibana/6.8/index.html"
     values.chart.helm.kubeaddons.mesosphere.io/kibana: "https://raw.githubusercontent.com/mesosphere/charts/73fba37/stable/kibana/values.yaml"
@@ -39,7 +39,7 @@ spec:
     values: |
       ---
       image:
-        tag: 6.8.10
+        tag: 6.8.15
       files:
         kibana.yml:
           ## Default Kibana configuration from kibana-docker.
@@ -66,7 +66,7 @@ spec:
         # https://github.com/mesosphere/kubeaddons-sidecars
         enabled: false
         values:
-          - kibana-prometheus-exporter,6.8.10,https://github.com/pjhampton/kibana-prometheus-exporter/releases/download/6.8.10/kibana-prometheus-exporter-6.8.10.zip
+          - kibana-prometheus-exporter,6.8.15,https://github.com/pjhampton/kibana-prometheus-exporter/releases/download/6.8.15/kibana-prometheus-exporter-6.8.15.zip
       extraContainers: |
         - name: create-index-patterns
           image: curlimages/curl
@@ -102,7 +102,7 @@ spec:
       initContainers:
         # from https://github.com/mesosphere/kubeaddons-sidecars
         - name: kibana-plugins-install
-          image: mesosphere/kibana-plugins:v6.8.10
+          image: mesosphere/kibana-plugins:v6.8.15
           command: ["/bin/sh", "-c", "cp -a /usr/share/kibana/plugins/. /usr/share/kibana/shared-plugins/"]
           volumeMounts:
           - name: plugins


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
This upgrades Kibana from 6.8.10 to 6.8.15 in order to pull in security updates.

**This is blocked on https://github.com/mesosphere/kubeaddons-sidecars/pull/4.**

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[kibana] Upgrade to 6.8.15. This should not be disruptive for the default configuration. This includes these security fixes:

* A field disclosure flaw was found in Elasticsearch when running a scrolling search with field level security. If a user runs the same query another more privileged user recently ran, the scrolling search can leak fields that should be hidden. This could result in an attacker gaining additional permissions against a restricted index. All versions of Elasticsearch before 7.9.0 and 6.8.12 are affected by this flaw. You must upgrade to Elasticsearch version 7.9.0 or 6.8.12 to obtain the fix. CVE-2020-7019
* Elasticsearch versions before 7.10.0 and 6.8.14 have an information disclosure issue when audit logging and the emit_request_body option are enabled. The Elasticsearch audit log could contain sensitive information, such as password hashes or authentication tokens. This could allow an Elasticsearch administrator to view these details. You must upgrade to Elasticsearch version 6.8.14 to obtain the fix. CVE-2020-7021
* A document disclosure flaw was found in the Elasticsearch suggester and profile API when Document and Field Level Security are enabled. The suggester and profile API are normally disabled for an index when document level security is enabled on the index. Certain queries are able to enable the profiler and suggester which could lead to disclosing the existence of documents and fields the attacker should not be able to view. All versions of Elasticsearch before 6.8.15 and 7.11.2 are affected by this flaw. You must upgrade to 6.8.15 or 7.11.2 to obtain the fix. CVE-2021-22137

https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.11.html
https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.12.html
https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.13.html
https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.14.html
https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.15.html
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [x] The documentation is updated where needed.
