### PR TITLE
[backport][tfa] clusterStorage disabled by default

### DIFF
--- a/addons/traefik-forward-auth/traefik-forward-auth.yaml
+++ b/addons/traefik-forward-auth/traefik-forward-auth.yaml
@@ -4,7 +4,9 @@ metadata:
   name: traefik-forward-auth
   namespace: kubeaddons
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.5-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "2.0.0-1"
+    helm.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=1.0.5", "strategy": "delete"}]'
+    helm2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=1.0.5", "strategy": "delete"}]'
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6

--- a/addons/traefik-forward-auth/traefik-forward-auth.yaml
+++ b/addons/traefik-forward-auth/traefik-forward-auth.yaml
@@ -96,6 +96,6 @@ spec:
         - name: "TFA_INGRESS_SERVICE_NAME"
           value: "traefik-kubeaddons"
       clusterStorage:
-        enabled: true
+        enabled: false
         namespace: kubeaddons
       addonsInitializer: mesosphere/kubeaddons-addon-initializer:v0.5.1

--- a/addons/traefik-forward-auth/traefik-forward-auth.yaml
+++ b/addons/traefik-forward-auth/traefik-forward-auth.yaml
@@ -29,13 +29,13 @@ spec:
   chartReference:
     chart: traefik-forward-auth
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.2.14
+    version: 0.3.0
     values: |
       ---
       replicaCount: 1
       image:
         repository: mesosphere/traefik-forward-auth
-        tag: 2.0.5
+        tag: 3.0.0
         pullPolicy: IfNotPresent
       resources:
         requests:
@@ -82,7 +82,7 @@ spec:
       initContainers:
       # initialize-traefik-forward-auth deploys credentials for use by the proxy
       - name: initialize-traefik-forward-auth
-        image: mesosphere/kubeaddons-addon-initializer:v0.2.9
+        image: mesosphere/kubeaddons-addon-initializer:v0.5.1
         args: ["traefikforwardauth"]
         env:
         - name: "TFA_CONFIGMAP_NAME"
@@ -93,3 +93,7 @@ spec:
           value: "kubeaddons"
         - name: "TFA_INGRESS_SERVICE_NAME"
           value: "traefik-kubeaddons"
+      clusterStorage:
+        enabled: true
+        namespace: kubeaddons
+      addonsInitializer: mesosphere/kubeaddons-addon-initializer:v0.5.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
backport of #1031 

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
no issue

**Special notes for your reviewer**:
This is a backport, clusterStorage is enabled on master

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[traefik-forward-auth] clusterStorage is now available as an experimental feature. When enabled, it configures session data to be stored in the cluster. This allows session persistence across replicas and pod restarts. 
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
