### PR TITLE
chore: make addons bump script execute only one a sprint

### DIFF
--- a/Dispatchfile
+++ b/Dispatchfile
@@ -205,4 +205,4 @@ action(tasks=["test-install", clean_install_kind, "test-upgrade", clean_upgrade_
 
 # Cron Actions
 do_bump_charts = bump_charts(repo_name="kubernetes-base-addons", task_name="kba-bumps")
-action(name="bump-charts", on=cron(schedule="0 3 * * 5"), tasks=[do_bump_charts])
+action(name="bump-charts", on=cron(schedule="0 3 7,21 * *"), tasks=[do_bump_charts])


### PR DESCRIPTION
**What type of PR is this?**
Chore

**What this PR does/ why we need it**:
Change the frequency of Cron bump to once a sprint as discussed in https://mesosphere.slack.com/archives/CQQ4HV5NY/p1619194135251500?thread_ts=1619183901.248600&cid=CQQ4HV5NY

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
