### PR TITLE
[auto-bump][chart] opsportal-0.8.0

### DIFF
--- a/addons/opsportal/opsportal.yaml
+++ b/addons/opsportal/opsportal.yaml
@@ -6,10 +6,10 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: opsportal
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.0-15"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.0-16"
     appversion.kubeaddons.mesosphere.io/opsportal: "1.5.0"
     endpoint.kubeaddons.mesosphere.io/opsportal: /ops/portal/
-    values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/8561f79/stable/opsportal/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/b12ed8f/stable/opsportal/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -29,7 +29,7 @@ spec:
   chartReference:
     chart: opsportal
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.7.2
+    version: 0.8.0
     valuesRemap:
       "kommander-ui.ingress.extraAnnotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
     values: |


### PR DESCRIPTION
##### Add Release Notes or "None":

```release-note
- UI - resolve kubecost performance issue
- UI - handle license loading state, show loading instead of invalid when license is missing a status
```
This is automated bump triggered from the source repo containing the updated Chart/Addon.
        