### PR TITLE
vsphere-csi-driver: bump to v2.2.0

### DIFF
--- a/addons/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/addons/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -7,9 +7,9 @@ metadata:
     kubeaddons.mesosphere.io/name: vsphere-csi-driver
     kubeaddons.mesosphere.io/provides: csi-driver
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.1-1"
-    appversion.kubeaddons.mesosphere.io/vsphere-csi-driver: "2.0.1"
-    values.chart.helm.kubeaddons.mesosphere.io/vsphere-csi-driver: "https://raw.githubusercontent.com/mesosphere/charts/5565912/stable/vsphere-csi-driver/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.0-1"
+    appversion.kubeaddons.mesosphere.io/vsphere-csi-driver: "2.2.0"
+    values.chart.helm.kubeaddons.mesosphere.io/vsphere-csi-driver: "https://raw.githubusercontent.com/mesosphere/charts/d0e5dd0/stable/vsphere-csi-driver/values.yaml"
 spec:
   requires:
     - matchLabels:
@@ -23,7 +23,7 @@ spec:
   chartReference:
     chart: vsphere-csi-driver
     repo: https://mesosphere.github.io/charts/stable
-    version: 1.2.1
+    version: 1.3.0
     values: |
       storageclass:
         # Fill it with your created and tagged vSphere Storage Policy


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Feature

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Bump [vsphere CSI to 2.2.0](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/docs/book/releases/v2.2.0.md).

[Ran e2e tests with these changes](https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_Konvoy_KonvoyE2eVsphere/3117932?buildTab=tests&status=passed).

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-75438

**Special notes for your reviewer**:

1. I pasted the upstream manifests in the first commit.
2. Added back the Helm templating.
3. Minor reverts to fix e2e failures.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update vpshere-csi-driver to v2.2.0 to pull in the fix for duplicate operations failure when attaching PVs (https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/580) (COPS-6906)
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
