### PR TITLE
prometheus: set nameOverride to preserve previous Service name

### DIFF
--- a/addons/flagger/flagger.yaml
+++ b/addons/flagger/flagger.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     sidecar.istio.io/inject: "false"
     appversion.kubeaddons.mesosphere.io/flagger: "0.19.0"
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.19.0-5"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.19.0-6"
     docs.kubeaddons.mesosphere.io/flagger: "https://docs.flagger.app/"
     values.chart.helm.kubeaddons.mesosphere.io/flagger: "https://raw.githubusercontent.com/mesosphere/charts/f4105ebb01fc758a4af356069a8ceae043201057/staging/flagger/values.yaml"
 spec:
@@ -38,7 +38,7 @@ spec:
     values: |
       ---
       meshProvider: istio
-      metricsServer: http://prometheus-kubeaddons-kube-prometheus.kubeaddons:9090
+      metricsServer: http://prometheus-kubeaddons-prom-prometheus.kubeaddons:9090
       podLabels:
         podmonitor.kubeaddons.mesosphere.io/path: "metrics"
         kubeaddons.mesosphere.io/name: "flagger"

--- a/addons/kiali/kiali.yaml
+++ b/addons/kiali/kiali.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kiali
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "v1.29.1-3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "v1.29.1-4"
     appversion.kubeaddons.mesosphere.io/kiali-operator: "v1.29.1"
     appversion.kubeaddons.mesosphere.io/kiali: "1.29.0"
     stage.kubeaddons.mesosphere.io/kiali: Experimental
@@ -55,7 +55,7 @@ spec:
             grafana:
               in_cluster_url: http://prometheus-kubeaddons-grafana.kubeaddons:3000
             prometheus:
-              url: http://prometheus-kubeaddons-kube-prometheus.kubeaddons:9090
+              url: http://prometheus-kubeaddons-prom-prometheus.kubeaddons:9090
             tracing:
               in_cluster_url: http://jaeger-kubeaddons-jaeger-operator-jaeger-query:16686
           deployment:

--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -9,7 +9,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.47.0-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.47.0-2"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.47.0"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.26.0"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.21.0"
@@ -52,6 +52,8 @@ spec:
       "grafana.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
     values: |
       ---
+      # override the name for a zero downtime upgrade from stable/prometheus-operator
+      nameOverride: prometheus-operator
       mesosphereResources:
         create: true
         rules:

--- a/addons/prometheusadapter/prometheusadapter.yaml
+++ b/addons/prometheusadapter/prometheusadapter.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: prometheusadapter
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "v0.8.3-3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "v0.8.3-4"
     appversion.kubeaddons.mesosphere.io/prometheusadapter: "v0.8.3"
     values.chart.helm.kubeaddons.mesosphere.io/prometheusadapter: "https://raw.githubusercontent.com/prometheus-community/helm-charts/61fb05e4f4ba9b6e4255a07338715414a3f493a0/charts/prometheus-adapter/values.yaml"
 spec:
@@ -35,7 +35,7 @@ spec:
     values: |
       ---
       prometheus:
-        url: http://prometheus-kubeaddons-kube-prometheus
+        url: http://prometheus-kubeaddons-prom-prometheus
       resources:
         limits:
            cpu: 2000m

--- a/test/nightly_prometheus_test.go
+++ b/test/nightly_prometheus_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -29,7 +30,7 @@ const (
 )
 
 func updateFixtures() bool {
-	return true //os.Getenv(updateFixturesEnvVar) == "true"
+	return os.Getenv(updateFixturesEnvVar) == "true"
 }
 
 func updateFixturesFatalMessage(err error) string {
@@ -56,9 +57,7 @@ func TestUnmarshallPrometheusMetricNames(t *testing.T) {
 	if updateFixtures() {
 		commentHeader := "used in TestUnmarshallPrometheusMetricNames as unit test output of prometheus-metric-output.json"
 		err := updatePrometheusMetricFixtures(prometheusMetricTestsFilename, commentHeader, metrics)
-		if err != nil {
-			t.Fatal(updateFixturesFatalMessage(err))
-		}
+		t.Fatal(updateFixturesFatalMessage(err))
 	}
 	err = testMetricFixtures(prometheusMetricTestsFilename, metrics)
 	if err != nil {

--- a/test/nightly_prometheus_test.go
+++ b/test/nightly_prometheus_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -30,7 +29,7 @@ const (
 )
 
 func updateFixtures() bool {
-	return os.Getenv(updateFixturesEnvVar) == "true"
+	return true //os.Getenv(updateFixturesEnvVar) == "true"
 }
 
 func updateFixturesFatalMessage(err error) string {
@@ -57,7 +56,9 @@ func TestUnmarshallPrometheusMetricNames(t *testing.T) {
 	if updateFixtures() {
 		commentHeader := "used in TestUnmarshallPrometheusMetricNames as unit test output of prometheus-metric-output.json"
 		err := updatePrometheusMetricFixtures(prometheusMetricTestsFilename, commentHeader, metrics)
-		t.Fatal(updateFixturesFatalMessage(err))
+		if err != nil {
+			t.Fatal(updateFixturesFatalMessage(err))
+		}
 	}
 	err = testMetricFixtures(prometheusMetricTestsFilename, metrics)
 	if err != nil {

--- a/test/prometheus_test.go
+++ b/test/prometheus_test.go
@@ -13,10 +13,10 @@ import (
 )
 
 const (
-	promPodPrefix = "prometheus-prometheus-kubeaddons-kube-prometheus-"
+	promPodPrefix = "prometheus-prometheus-kubeaddons-prom-prometheus-"
 	promPort      = "9090"
 
-	alertmanagerPodPrefix = "alertmanager-prometheus-kubeaddons-kube-alertmanager-"
+	alertmanagerPodPrefix = "alertmanager-prometheus-kubeaddons-prom-alertmanager-"
 	alertmanagerPort      = "9093"
 
 	grafanaPodPrefix = "prometheus-kubeaddons-grafana"

--- a/test/testdata/prometheus-metric-output.json
+++ b/test/testdata/prometheus-metric-output.json
@@ -18277,10 +18277,10 @@
           "__name__": "up",
           "endpoint": "http",
           "instance": "192.168.136.19:8080",
-          "job": "prometheus-kubeaddons-kube-operator",
+          "job": "prometheus-kubeaddons-prom-operator",
           "namespace": "kubeaddons",
-          "pod": "prometheus-kubeaddons-kube-operator-6db988ccc4-qwrk6",
-          "service": "prometheus-kubeaddons-kube-operator"
+          "pod": "prometheus-kubeaddons-prom-operator-6db988ccc4-qwrk6",
+          "service": "prometheus-kubeaddons-prom-operator"
         },
         "values": [
           [
@@ -29233,7 +29233,7 @@
           "job": "kube-proxy",
           "namespace": "kube-system",
           "pod": "kube-proxy-z2whp",
-          "service": "prometheus-kubeaddons-kube-kube-proxy"
+          "service": "prometheus-kubeaddons-prom-kube-proxy"
         },
         "values": [
           [
@@ -30450,7 +30450,7 @@
           "job": "kube-proxy",
           "namespace": "kube-system",
           "pod": "kube-proxy-7xm8c",
-          "service": "prometheus-kubeaddons-kube-kube-proxy"
+          "service": "prometheus-kubeaddons-prom-kube-proxy"
         },
         "values": [
           [
@@ -31667,7 +31667,7 @@
           "job": "kube-proxy",
           "namespace": "kube-system",
           "pod": "kube-proxy-xw8g4",
-          "service": "prometheus-kubeaddons-kube-kube-proxy"
+          "service": "prometheus-kubeaddons-prom-kube-proxy"
         },
         "values": [
           [
@@ -32884,7 +32884,7 @@
           "job": "kube-proxy",
           "namespace": "kube-system",
           "pod": "kube-proxy-njwtv",
-          "service": "prometheus-kubeaddons-kube-kube-proxy"
+          "service": "prometheus-kubeaddons-prom-kube-proxy"
         },
         "values": [
           [
@@ -34101,7 +34101,7 @@
           "job": "kube-proxy",
           "namespace": "kube-system",
           "pod": "kube-proxy-6ngmw",
-          "service": "prometheus-kubeaddons-kube-kube-proxy"
+          "service": "prometheus-kubeaddons-prom-kube-proxy"
         },
         "values": [
           [
@@ -35318,7 +35318,7 @@
           "job": "kube-proxy",
           "namespace": "kube-system",
           "pod": "kube-proxy-zg76x",
-          "service": "prometheus-kubeaddons-kube-kube-proxy"
+          "service": "prometheus-kubeaddons-prom-kube-proxy"
         },
         "values": [
           [
@@ -36535,7 +36535,7 @@
           "job": "kube-proxy",
           "namespace": "kube-system",
           "pod": "kube-proxy-nrpkv",
-          "service": "prometheus-kubeaddons-kube-kube-proxy"
+          "service": "prometheus-kubeaddons-prom-kube-proxy"
         },
         "values": [
           [
@@ -37752,7 +37752,7 @@
           "job": "coredns",
           "namespace": "kube-system",
           "pod": "coredns-6955765f44-rgsfc",
-          "service": "prometheus-kubeaddons-kube-coredns"
+          "service": "prometheus-kubeaddons-prom-coredns"
         },
         "values": [
           [
@@ -38969,7 +38969,7 @@
           "job": "coredns",
           "namespace": "kube-system",
           "pod": "coredns-6955765f44-gjjr9",
-          "service": "prometheus-kubeaddons-kube-coredns"
+          "service": "prometheus-kubeaddons-prom-coredns"
         },
         "values": [
           [
@@ -43835,7 +43835,7 @@
           "metrics_path": "/metrics",
           "namespace": "kube-system",
           "node": "ip-10-0-128-80.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -45053,7 +45053,7 @@
           "metrics_path": "/metrics/cadvisor",
           "namespace": "kube-system",
           "node": "ip-10-0-128-80.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -46271,7 +46271,7 @@
           "metrics_path": "/metrics/probes",
           "namespace": "kube-system",
           "node": "ip-10-0-128-80.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -47489,7 +47489,7 @@
           "metrics_path": "/metrics/resource/v1alpha1",
           "namespace": "kube-system",
           "node": "ip-10-0-128-80.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -48707,7 +48707,7 @@
           "metrics_path": "/metrics",
           "namespace": "kube-system",
           "node": "ip-10-0-129-168.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -49925,7 +49925,7 @@
           "metrics_path": "/metrics/cadvisor",
           "namespace": "kube-system",
           "node": "ip-10-0-129-168.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -51143,7 +51143,7 @@
           "metrics_path": "/metrics/probes",
           "namespace": "kube-system",
           "node": "ip-10-0-129-168.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -52361,7 +52361,7 @@
           "metrics_path": "/metrics/resource/v1alpha1",
           "namespace": "kube-system",
           "node": "ip-10-0-129-168.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -53579,7 +53579,7 @@
           "metrics_path": "/metrics",
           "namespace": "kube-system",
           "node": "ip-10-0-129-228.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -54797,7 +54797,7 @@
           "metrics_path": "/metrics/cadvisor",
           "namespace": "kube-system",
           "node": "ip-10-0-129-228.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -56015,7 +56015,7 @@
           "metrics_path": "/metrics/probes",
           "namespace": "kube-system",
           "node": "ip-10-0-129-228.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -57233,7 +57233,7 @@
           "metrics_path": "/metrics/resource/v1alpha1",
           "namespace": "kube-system",
           "node": "ip-10-0-129-228.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -58451,7 +58451,7 @@
           "metrics_path": "/metrics",
           "namespace": "kube-system",
           "node": "ip-10-0-129-244.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -59669,7 +59669,7 @@
           "metrics_path": "/metrics/cadvisor",
           "namespace": "kube-system",
           "node": "ip-10-0-129-244.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -60887,7 +60887,7 @@
           "metrics_path": "/metrics/probes",
           "namespace": "kube-system",
           "node": "ip-10-0-129-244.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -62105,7 +62105,7 @@
           "metrics_path": "/metrics/resource/v1alpha1",
           "namespace": "kube-system",
           "node": "ip-10-0-129-244.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -63323,7 +63323,7 @@
           "metrics_path": "/metrics",
           "namespace": "kube-system",
           "node": "ip-10-0-194-126.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -64541,7 +64541,7 @@
           "metrics_path": "/metrics/cadvisor",
           "namespace": "kube-system",
           "node": "ip-10-0-194-126.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -65759,7 +65759,7 @@
           "metrics_path": "/metrics/probes",
           "namespace": "kube-system",
           "node": "ip-10-0-194-126.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -66977,7 +66977,7 @@
           "metrics_path": "/metrics/resource/v1alpha1",
           "namespace": "kube-system",
           "node": "ip-10-0-194-126.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -68195,7 +68195,7 @@
           "metrics_path": "/metrics",
           "namespace": "kube-system",
           "node": "ip-10-0-194-47.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -69413,7 +69413,7 @@
           "metrics_path": "/metrics/cadvisor",
           "namespace": "kube-system",
           "node": "ip-10-0-194-47.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -70631,7 +70631,7 @@
           "metrics_path": "/metrics/probes",
           "namespace": "kube-system",
           "node": "ip-10-0-194-47.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -71849,7 +71849,7 @@
           "metrics_path": "/metrics/resource/v1alpha1",
           "namespace": "kube-system",
           "node": "ip-10-0-194-47.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -73067,7 +73067,7 @@
           "metrics_path": "/metrics",
           "namespace": "kube-system",
           "node": "ip-10-0-195-99.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -74285,7 +74285,7 @@
           "metrics_path": "/metrics/cadvisor",
           "namespace": "kube-system",
           "node": "ip-10-0-195-99.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -75503,7 +75503,7 @@
           "metrics_path": "/metrics/probes",
           "namespace": "kube-system",
           "node": "ip-10-0-195-99.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -76721,7 +76721,7 @@
           "metrics_path": "/metrics/resource/v1alpha1",
           "namespace": "kube-system",
           "node": "ip-10-0-195-99.us-west-2.compute.internal",
-          "service": "prometheus-kubeaddons-kube-kubelet"
+          "service": "prometheus-kubeaddons-prom-kubelet"
         },
         "values": [
           [
@@ -93756,10 +93756,10 @@
           "__name__": "up",
           "endpoint": "web",
           "instance": "192.168.174.73:9093",
-          "job": "prometheus-kubeaddons-kube-alertmanager",
+          "job": "prometheus-kubeaddons-prom-alertmanager",
           "namespace": "kubeaddons",
-          "pod": "alertmanager-prometheus-kubeaddons-kube-alertmanager-0",
-          "service": "prometheus-kubeaddons-kube-alertmanager"
+          "pod": "alertmanager-prometheus-kubeaddons-prom-alertmanager-0",
+          "service": "prometheus-kubeaddons-prom-alertmanager"
         },
         "values": [
           [
@@ -94973,10 +94973,10 @@
           "__name__": "up",
           "endpoint": "web",
           "instance": "192.168.174.74:9090",
-          "job": "prometheus-kubeaddons-kube-prometheus",
+          "job": "prometheus-kubeaddons-prom-prometheus",
           "namespace": "kubeaddons",
-          "pod": "prometheus-prometheus-kubeaddons-kube-prometheus-0",
-          "service": "prometheus-kubeaddons-kube-prometheus"
+          "pod": "prometheus-prometheus-kubeaddons-prom-prometheus-0",
+          "service": "prometheus-kubeaddons-prom-prometheus"
         },
         "values": [
           [

--- a/test/testdata/prometheus-metric-tests.yaml
+++ b/test/testdata/prometheus-metric-tests.yaml
@@ -17,17 +17,17 @@
 - name: up
   app: ""
   namespace: kube-system
-  service: prometheus-kubeaddons-kube-coredns
+  service: prometheus-kubeaddons-prom-coredns
   job: coredns
 - name: up
   app: ""
   namespace: kube-system
-  service: prometheus-kubeaddons-kube-kube-proxy
+  service: prometheus-kubeaddons-prom-kube-proxy
   job: kube-proxy
 - name: up
   app: ""
   namespace: kube-system
-  service: prometheus-kubeaddons-kube-kubelet
+  service: prometheus-kubeaddons-prom-kubelet
   job: kubelet
 - name: up
   app: ""
@@ -57,23 +57,23 @@
 - name: up
   app: ""
   namespace: kubeaddons
-  service: prometheus-kubeaddons-kube-alertmanager
-  job: prometheus-kubeaddons-kube-alertmanager
-- name: up
-  app: ""
-  namespace: kubeaddons
-  service: prometheus-kubeaddons-kube-operator
-  job: prometheus-kubeaddons-kube-operator
-- name: up
-  app: ""
-  namespace: kubeaddons
-  service: prometheus-kubeaddons-kube-prometheus
-  job: prometheus-kubeaddons-kube-prometheus
-- name: up
-  app: ""
-  namespace: kubeaddons
   service: prometheus-kubeaddons-kube-state-metrics
   job: kube-state-metrics
+- name: up
+  app: ""
+  namespace: kubeaddons
+  service: prometheus-kubeaddons-prom-alertmanager
+  job: prometheus-kubeaddons-prom-alertmanager
+- name: up
+  app: ""
+  namespace: kubeaddons
+  service: prometheus-kubeaddons-prom-operator
+  job: prometheus-kubeaddons-prom-operator
+- name: up
+  app: ""
+  namespace: kubeaddons
+  service: prometheus-kubeaddons-prom-prometheus
+  job: prometheus-kubeaddons-prom-prometheus
 - name: up
   app: ""
   namespace: kubeaddons

--- a/test/testdata/test-nightly-group-prom-metric-tests.yaml
+++ b/test/testdata/test-nightly-group-prom-metric-tests.yaml
@@ -17,17 +17,17 @@
 - name: up
   app: ""
   namespace: kube-system
-  service: prometheus-kubeaddons-kube-coredns
+  service: prometheus-kubeaddons-prom-coredns
   job: coredns
 - name: up
   app: ""
   namespace: kube-system
-  service: prometheus-kubeaddons-kube-kube-proxy
+  service: prometheus-kubeaddons-prom-kube-proxy
   job: kube-proxy
 - name: up
   app: ""
   namespace: kube-system
-  service: prometheus-kubeaddons-kube-kubelet
+  service: prometheus-kubeaddons-prom-kubelet
   job: kubelet
 - name: up
   app: ""
@@ -57,23 +57,23 @@
 - name: up
   app: ""
   namespace: kubeaddons
-  service: prometheus-kubeaddons-kube-alertmanager
-  job: prometheus-kubeaddons-kube-alertmanager
-- name: up
-  app: ""
-  namespace: kubeaddons
-  service: prometheus-kubeaddons-kube-operator
-  job: prometheus-kubeaddons-kube-operator
-- name: up
-  app: ""
-  namespace: kubeaddons
-  service: prometheus-kubeaddons-kube-prometheus
-  job: prometheus-kubeaddons-kube-prometheus
-- name: up
-  app: ""
-  namespace: kubeaddons
   service: prometheus-kubeaddons-kube-state-metrics
   job: kube-state-metrics
+- name: up
+  app: ""
+  namespace: kubeaddons
+  service: prometheus-kubeaddons-prom-alertmanager
+  job: prometheus-kubeaddons-prom-alertmanager
+- name: up
+  app: ""
+  namespace: kubeaddons
+  service: prometheus-kubeaddons-prom-operator
+  job: prometheus-kubeaddons-prom-operator
+- name: up
+  app: ""
+  namespace: kubeaddons
+  service: prometheus-kubeaddons-prom-prometheus
+  job: prometheus-kubeaddons-prom-prometheus
 - name: up
   app: ""
   namespace: kubeaddons


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Following the [chart recommendation](https://github.com/mesosphere/charts/tree/master/staging/prometheus-operator#zero-downtime) setting `nameOverride` for the Prometheus addon.

Also reverted the changes back to the old service.

Cluster with this version
```
Run `konvoy apply kubeconfig` to update kubectl credentials.

Navigate to the URL below to access various services running in the cluster.
  https://a45c58c39b0c64dcdb9193df5f0d6fa4-1473442938.us-west-2.elb.amazonaws.com/ops/landing
And login using the credentials below.
  Username: eloquent_mclean
  Password: O7C1tyooQbiLMRu7D1VyPWy0IVKOm6n9N9DAxPJlNE2IPiqwJcSQS7JdpAkJdVPp

If the cluster was recently created, the dashboard and services may take a few minutes to be accessible.
```

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Prometheus: preserve the name `prometheus-operator` to avoid breaking any Prometheus metrics clients.
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
