### PR TITLE
fix: change Nvidia metrics path

### DIFF
--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -9,7 +9,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.47.0-2"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.47.0-3"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.47.0"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.26.0"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.21.0"
@@ -252,7 +252,7 @@ spec:
                   replacement: '${1}:1338'
                   target_label: __address__
             - job_name: 'gpu_metrics'
-              metrics_path: /gpu/metrics
+              metrics_path: /metrics
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
               bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->

Bug

**What this PR does/ why we need it**:
When the Prometheus exporter for Nvidia was updated, it changed the path for metrics, but the path was not updated in the Prometheus config.

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-75529

**Special notes for your reviewer**:

Starting a cluster with GPU nodes for master shows no data on the Nvidia dashboard. With this change, the data appears.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
