### PR TITLE
chore: fix dependabot configuration for lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,48 +1,49 @@
+---
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/test"
-  schedule:
-    interval: daily
-    time: "13:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: k8s.io/client-go
-    versions:
-    - 0.20.2
-    - 0.20.3
-    - 0.20.4
-    - 0.21.0
-  - dependency-name: k8s.io/apimachinery
-    versions:
-    - 0.20.3
-    - 0.20.4
-    - 0.20.5
-    - 0.21.0
-  - dependency-name: k8s.io/api
-    versions:
-    - 0.20.3
-    - 0.20.5
-    - 0.21.0
-  - dependency-name: github.com/mesosphere/kubeaddons
-    versions:
-    - 0.23.12
-    - 0.23.13
-    - 0.24.0
-    - 0.24.1
-    - 0.25.0
-    - 0.26.0
-  - dependency-name: sigs.k8s.io/controller-runtime
-    versions:
-    - 0.8.2
-  - dependency-name: github.com/datawire/ambassador
-    versions:
-    - 1.11.1
-  - dependency-name: github.com/mesosphere/ksphere-testing-framework
-    versions:
-    - 0.2.4
-    - 0.2.5
-    - 0.2.6
-  - dependency-name: sigs.k8s.io/kind
-    versions:
-    - 0.10.0
+  - package-ecosystem: gomod
+    directory: "/test"
+    schedule:
+      interval: daily
+      time: "13:00"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: k8s.io/client-go
+        versions:
+          - 0.20.2
+          - 0.20.3
+          - 0.20.4
+          - 0.21.0
+      - dependency-name: k8s.io/apimachinery
+        versions:
+          - 0.20.3
+          - 0.20.4
+          - 0.20.5
+          - 0.21.0
+      - dependency-name: k8s.io/api
+        versions:
+          - 0.20.3
+          - 0.20.5
+          - 0.21.0
+      - dependency-name: github.com/mesosphere/kubeaddons
+        versions:
+          - 0.23.12
+          - 0.23.13
+          - 0.24.0
+          - 0.24.1
+          - 0.25.0
+          - 0.26.0
+      - dependency-name: sigs.k8s.io/controller-runtime
+        versions:
+          - 0.8.2
+      - dependency-name: github.com/datawire/ambassador
+        versions:
+          - 1.11.1
+      - dependency-name: github.com/mesosphere/ksphere-testing-framework
+        versions:
+          - 0.2.4
+          - 0.2.5
+          - 0.2.6
+      - dependency-name: sigs.k8s.io/kind
+        versions:
+          - 0.10.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
PR #1093 broke the YAML lint test, making all subsequent lints fail.

This PR formats the added file to pass linting.

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->
no issue

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Checklist**

* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
