### PR TITLE
[auto-bump][chart] velero-3.1.2

### DIFF
--- a/addons/velero/velero.yaml
+++ b/addons/velero/velero.yaml
@@ -30,8 +30,8 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.2-2"
-    values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/mesosphere/charts/34a717f/staging/velero/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.2-1"
+    values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/mesosphere/charts/c0ec685/staging/velero/values.yaml"
     # minio StatefulSet changes too much to be updated
     helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=3.0.6\", \"strategy\": \"delete\"}]"
     helm2.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=3.0.6\", \"strategy\": \"delete\"}]"
@@ -56,7 +56,7 @@ spec:
   chartReference:
     chart: velero
     repo: https://mesosphere.github.io/charts/staging
-    version: 3.1.1
+    version: 3.1.2
     values: |
       ---
       enableHelmHooks: false # handle helm install --atomic through kubeaddons


### PR DESCRIPTION
- fix(velero): Duplicate s3ForcePathStyle config key
- chore(velero): Bump chart version to 3.1.2

**What type of PR is this?**
Bug

**What this PR does/ why we need it**:
When specifying `s3ForcePathStyle`, the helm template renders a duplicate key which breaks with helm 3.6.0:

```bash
$ helm template m-staging/velero --set configuration.backupStorageLocation.config.s3ForcePathStyle=true 2>/dev/null | grep -B 1 s3ForcePathStyle 2>/dev/null
  config:
    s3ForcePathStyle: true
    s3ForcePathStyle: "true"
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix duplicate keys in velero backupstoragelocation configuration.
```

**Checklist**

* [X] *If a chart is changed, the chart version is correctly incremented.*
* [X] The commit message explains the changes and why are needed.
* [X] The code builds and passes lint/style checks locally.
* [X] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
