### PR TITLE
[auto-bump][chart] kube-prometheus-stack-15.4.7

### DIFF
--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -9,7 +9,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.47.0-3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.47.0-1"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.47.0"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.26.0"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.21.0"
@@ -17,10 +17,10 @@ metadata:
     endpoint.kubeaddons.mesosphere.io/prometheus: "/ops/portal/prometheus"
     endpoint.kubeaddons.mesosphere.io/alertmanager: "/ops/portal/alertmanager"
     endpoint.kubeaddons.mesosphere.io/grafana: "/ops/portal/grafana"
-    docs.kubeaddons.mesosphere.io/prometheus: "https://prometheus.io/docs/introduction/overview/"
-    docs.kubeaddons.mesosphere.io/grafana: "https://grafana.com/docs/"
-    docs.kubeaddons.mesosphere.io/alertmanager: "https://prometheus.io/docs/alerting/alertmanager/"
-    values.chart.helm.kubeaddons.mesosphere.io/prometheus: "https://raw.githubusercontent.com/mesosphere/charts/64e5c540ec8273cc7135babfde94a57495bbc52b/staging/prometheus-operator/values.yaml"
+    docs.kubeaddons.mesosphere.io/prometheus: "0.47h0.47t0.47t0.47p0.47s0.47:0.47/0.47/0.47p0.47r0.47o0.47m0.47e0.47t0.47h0.47e0.47u0.47s0.47.0.47i0.47o0.47/0.47d0.47o0.47c0.47s0.47/0.47i0.47n0.47t0.47r0.47o0.47d0.47u0.47c0.47t0.47i0.47o0.47n0.47/0.47o0.47v0.47e0.47r0.47v0.47i0.47e0.47w0.47/0.47"
+    docs.kubeaddons.mesosphere.io/grafana: "0.47h0.47t0.47t0.47p0.47s0.47:0.47/0.47/0.47g0.47r0.47a0.47f0.47a0.47n0.47a0.47.0.47c0.47o0.47m0.47/0.47d0.47o0.47c0.47s0.47/0.47"
+    docs.kubeaddons.mesosphere.io/alertmanager: "0.47h0.47t0.47t0.47p0.47s0.47:0.47/0.47/0.47p0.47r0.47o0.47m0.47e0.47t0.47h0.47e0.47u0.47s0.47.0.47i0.47o0.47/0.47d0.47o0.47c0.47s0.47/0.47a0.47l0.47e0.47r0.47t0.47i0.47n0.47g0.47/0.47a0.47l0.47e0.47r0.47t0.47m0.47a0.47n0.47a0.47g0.47e0.47r0.47/0.47"
+    values.chart.helm.kubeaddons.mesosphere.io/prometheus: "https://raw.githubusercontent.com/mesosphere/charts/c0ec685/staging/prometheus-operator/values.yaml"
     # The prometheus-operator chart from prior Konvoy releases can't be upgraded to 8.10.0.
     # See https://github.com/helm/charts/issues/21200.
     # 8.8.5 was the latest version available in mesosphere/charts before it was bumped past 8.10.0.
@@ -45,7 +45,7 @@ spec:
   chartReference:
     chart: kube-prometheus-stack
     repo: https://mesosphere.github.io/charts/staging
-    version: 15.4.5
+    version: 15.4.7
     valuesRemap:
       "prometheus.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
       "alertmanager.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"


### PR DESCRIPTION

##### Add Release Notes or "None":

```release-note

```
This is automated bump triggered from the source repo containing the updated Chart/Addon.
        