### PR TITLE
[auto-bump][chart] kube-prometheus-stack-16.13.1

### DIFF
--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -9,7 +9,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.47.0-4"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.48.1-1"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.47.0"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.26.0"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.21.0"
@@ -17,10 +17,10 @@ metadata:
     endpoint.kubeaddons.mesosphere.io/prometheus: "/ops/portal/prometheus"
     endpoint.kubeaddons.mesosphere.io/alertmanager: "/ops/portal/alertmanager"
     endpoint.kubeaddons.mesosphere.io/grafana: "/ops/portal/grafana"
-    docs.kubeaddons.mesosphere.io/prometheus: "https://prometheus.io/docs/introduction/overview/"
-    docs.kubeaddons.mesosphere.io/grafana: "https://grafana.com/docs/"
-    docs.kubeaddons.mesosphere.io/alertmanager: "https://prometheus.io/docs/alerting/alertmanager/"
-    values.chart.helm.kubeaddons.mesosphere.io/prometheus: "https://raw.githubusercontent.com/mesosphere/charts/c0ec6852189730af8fb34ed2a62b1b79a959bfc5/staging/kube-prometheus-stack/values.yaml"
+    docs.kubeaddons.mesosphere.io/prometheus: "0.48h0.48t0.48t0.48p0.48s0.48:0.48/0.48/0.48p0.48r0.48o0.48m0.48e0.48t0.48h0.48e0.48u0.48s0.48.0.48i0.48o0.48/0.48d0.48o0.48c0.48s0.48/0.48i0.48n0.48t0.48r0.48o0.48d0.48u0.48c0.48t0.48i0.48o0.48n0.48/0.48o0.48v0.48e0.48r0.48v0.48i0.48e0.48w0.48/0.48"
+    docs.kubeaddons.mesosphere.io/grafana: "0.48h0.48t0.48t0.48p0.48s0.48:0.48/0.48/0.48g0.48r0.48a0.48f0.48a0.48n0.48a0.48.0.48c0.48o0.48m0.48/0.48d0.48o0.48c0.48s0.48/0.48"
+    docs.kubeaddons.mesosphere.io/alertmanager: "0.48h0.48t0.48t0.48p0.48s0.48:0.48/0.48/0.48p0.48r0.48o0.48m0.48e0.48t0.48h0.48e0.48u0.48s0.48.0.48i0.48o0.48/0.48d0.48o0.48c0.48s0.48/0.48a0.48l0.48e0.48r0.48t0.48i0.48n0.48g0.48/0.48a0.48l0.48e0.48r0.48t0.48m0.48a0.48n0.48a0.48g0.48e0.48r0.48/0.48"
+    values.chart.helm.kubeaddons.mesosphere.io/prometheus: "https://raw.githubusercontent.com/mesosphere/charts/1688a37/staging/kube-prometheus-stack/values.yaml"
     # The prometheus-operator chart from prior Konvoy releases can't be upgraded to 8.10.0.
     # See https://github.com/helm/charts/issues/21200.
     # 8.8.5 was the latest version available in mesosphere/charts before it was bumped past 8.10.0.
@@ -45,7 +45,7 @@ spec:
   chartReference:
     chart: kube-prometheus-stack
     repo: https://mesosphere.github.io/charts/staging
-    version: 15.4.7
+    version: 16.13.1
     valuesRemap:
       "prometheus.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
       "alertmanager.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"


### PR DESCRIPTION

##### Add Release Notes or "None":

```release-note

```
This is automated bump triggered from the source repo containing the updated Chart/Addon.
        