### PR TITLE
[auto-bump][chart] ambassador-6.7.13

### DIFF
--- a/addons/ambassador/ambassador.yaml
+++ b/addons/ambassador/ambassador.yaml
@@ -9,10 +9,10 @@ metadata:
     kubeaddons.mesosphere.io/name: ambassador
     kubeaddons.mesosphere.io/provides: ingresscontroller
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.13.3-1"
-    appversion.kubeaddons.mesosphere.io/ambassador: "1.13.3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.13.10-1"
+    appversion.kubeaddons.mesosphere.io/ambassador: "1.13.10"
     docs.kubeaddons.mesosphere.io/ambassador: "https://www.getambassador.io/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/ambassador: "https://raw.githubusercontent.com/datawire/ambassador/54d2411acd0e91264bebd9eb0dffa4942c540f05/charts/ambassador/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/ambassador: "https://raw.githubusercontent.com/datawire/ambassador/b394c5e/charts/ambassador/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.17.11
@@ -34,7 +34,7 @@ spec:
   chartReference:
     chart: ambassador
     repo: https://getambassador.io
-    version: 6.7.5
+    version: 6.7.13
     values: |
       enableAES: false # use the OSS features
       image:

--- a/test/ambassador_test.go
+++ b/test/ambassador_test.go
@@ -114,7 +114,7 @@ func ambassadorChecker(t *testing.T, cluster testcluster.Cluster) testharness.Jo
 
 		// I've checked with upstream, even though there's a status available in the Mapping API, they don't use it since several
 		// versions ago, so for the time being we just give the mapping a reasonable amount of time to resolve.
-		time.Sleep(time.Second * 10)
+		time.Sleep(time.Second * 20)
 
 		// get the svc IP for ambassador
 		localport, stop, err := portForwardPodWithPrefix(cluster, constants.DefaultAddonNamespace, "ambassador", "8080")


### PR DESCRIPTION
##### Add Release Notes or "None":

```release-note
[1.13.10]
- Bugfix: Fixed a regression when specifying a comma separated string for `cors.origins` on the
  `Mapping` resource. ([#3609])
- Change: Envoy-configuration snapshots get saved (as `ambex-#.json`) in `/ambassador/snapshots`.
  The number of snapshots is controlled by the `AMBASSADOR_AMBEX_SNAPSHOT_COUNT` environment
  variable; set it to 0 to disable. The default is 30.
- Change: Set `AMBASSADOR_AMBEX_NO_RATELIMIT` to `true` to completely disable ratelimiting Envoy
  reconfiguration under memory pressure. This can help performance with the endpoint or Consul
  resolvers, but could make OOMkills more likely with large configurations. The default is `false`,
  meaning that the rate limiter is active.
- Bugfix: The `Mapping` resource can now specify `docs.timeout_ms` to set the timeout when the 
  Dev Portal is fetching API specifications.
- Bugfix: The Dev Portal will now strip HTML tags when displaying search results, showing just
  the actual content of the search result.
- Change: Consul certificate-rotation logging now includes the fingerprints and validity
  timestamps of certificates being rotated.

[1.13.8]
- Bugfix: Ambassador Agent now accurately reports up-to-date Endpoint information to Ambassador Cloud
- Feature: Ambassador Agent reports ConfigMaps and Deployments to Ambassador Cloud to provide a better Argo Rollouts experience. See [Argo+Ambassador documentation](https://www.getambassador.io/docs/argo) for more info.

[1.13.7]
- Feature: Add AMBASSADOR_JSON_LOGGING to enable JSON for most of the Ambassador control plane. Some (but few) logs from gunicorn and the Kubernetes client-go package still log text.
- Bugfix: Fixed a bug where the Consul resolver would not actually use Consul endpoints with TCPMappings.
- Change: Ambassador now calculates its own memory usage in a way that is more similar to how the kernel OOMKiller tracks memory.

[1.13.6]
- Bugfix: Fixed a regression where Ambassador snapshot data was logged at the INFO label when using AMBASSADOR_LEGACY_MODE=true

[1.13.5]
- Bugfix: Fix a regression from 1.8.0 that prevented Ambassador module config keys `proper_case` and `preserve_external_request_id` from working correctly.
- Bugfix: Fixed a regression in detecting the Ambassador Kubernetes service that could cause the wrong IP or hostname to be used in Ingress statuses (thanks, [Noah Fontes](https://github.com/impl)!

[1.13.4]
- Bugfix: Incorporate the Envoy 1.15.5 security update by adding the `reject_requests_with_escaped_slashes` option to the Ambassador module.
```
This is automated bump triggered from the source repo containing the updated Chart/Addon.
        