### PR TITLE
[auto-bump][chart] azuredisk-csi-driver-0.8.0

### DIFF
--- a/addons/azuredisk-csi-driver/azuredisk-csi-driver.yaml
+++ b/addons/azuredisk-csi-driver/azuredisk-csi-driver.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: ClusterAddon
 metadata:
@@ -7,9 +6,9 @@ metadata:
     kubeaddons.mesosphere.io/name: azuredisk-csi-driver
     kubeaddons.mesosphere.io/provides: csi-driver
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.7.2-3"
-    appversion.kubeaddons.mesosphere.io/azuredisk-csi-driver: "0.7.2"
-    values.chart.helm.kubeaddons.mesosphere.io/azuredisk-csi-driver: "https://raw.githubusercontent.com/mesosphere/charts/68420c0ec86604d5abab5e635fd9ab4123ef1d07/stable/azuredisk-csi-driver/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.1-1"
+    appversion.kubeaddons.mesosphere.io/azuredisk-csi-driver: "1.1.1"
+    values.chart.helm.kubeaddons.mesosphere.io/azuredisk-csi-driver: "https://raw.githubusercontent.com/mesosphere/charts/8b85fea/stable/azuredisk-csi-driver/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -20,7 +19,7 @@ spec:
   chartReference:
     chart: azuredisk-csi-driver
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.7.2
+    version: 0.8.0
     values: |
       ---
       snapshot:


### PR DESCRIPTION
##### Add Release Notes or "None":

```release-note
Features 

- support force detach
- support incremental snapshot
- support tags in snapshot
- create snapshot on external resource group
- add dangling error support
- support Azure disk batch attach/detach (#650)
- Windows beta support (switch to csi-proxy v0.2.2 API)
- support multi OS versions for Windows images
- Azure stack support
- ListVolumes support
- add LogicalSectorSize support for UltraSSD
- remove unmanaged disk support
- add full Azure Stack support
- add more controller metrics
- support disable AzureStack
- disable AzureStack by DisableAzureStackCloud config

Bug Fixes 

- fix disk API 10s latency issue
- fix initial delay(1s) when mount azure disk
- fix incorrect max azure disk max count
- fix resize error in migration scenario
- fix azure disk resize error if source does not exist
- fix: not schedule driver pod on virtual node
- fix: cache data loss issue on Windows when unmount disk
- fix: resize filesystem if cloned volume capacity is larger than source volume
- fix: volume expansion failure on node
- fix: helm chart installation issue
```
This is automated bump triggered from the source repo containing the updated Chart/Addon.
        