### PR TITLE
[auto-bump][chart] kubernetes-dashboard-4.5.0

### DIFF
--- a/addons/dashboard/dashboard.yaml
+++ b/addons/dashboard/dashboard.yaml
@@ -5,11 +5,11 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dashboard
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "3.0.2-1"
-    appversion.kubeaddons.mesosphere.io/dashboard: "2.2.0"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "2.3.1-1"
+    appversion.kubeaddons.mesosphere.io/dashboard: "2.3.1"
     endpoint.kubeaddons.mesosphere.io/dashboard: "/ops/portal/kubernetes/"
     docs.kubeaddons.mesosphere.io/dashboard: "https://github.com/kubernetes/dashboard/blob/master/README.md"
-    values.chart.helm.kubeaddons.mesosphere.io/dashboard: "https://raw.githubusercontent.com/helm/charts/7e45e67/stable/kubernetes-dashboard/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/dashboard: "https://raw.githubusercontent.com/helm/charts/f4f301a/stable/kubernetes-dashboard/values.yaml"
     # versions of the dashboard older than v2 are not directly compatible and so a delete uprade is needed in this case to avoid conflicts with the older resources.
     helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=2.0.0\", \"strategy\": \"delete\"}]"
     helm2.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=2.0.0\", \"strategy\": \"delete\"}]"
@@ -33,7 +33,7 @@ spec:
   chartReference:
     chart: kubernetes-dashboard
     repo: https://kubernetes.github.io/dashboard/
-    version: 4.0.3
+    version: 4.5.0
     valuesRemap:
       "ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
     values: |

--- a/addons/dashboard/dashboard.yaml
+++ b/addons/dashboard/dashboard.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dashboard
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "2.3.1-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "3.1.0-1"
     appversion.kubeaddons.mesosphere.io/dashboard: "2.3.1"
     endpoint.kubeaddons.mesosphere.io/dashboard: "/ops/portal/kubernetes/"
     docs.kubeaddons.mesosphere.io/dashboard: "https://github.com/kubernetes/dashboard/blob/master/README.md"


### PR DESCRIPTION
##### Add Release Notes or "None":

```release-note
- Hide pagination controls if there is only a single page of items to display (#5827)
- Use .log extension instead of .txt for downloaded log files
- Extend pod view with more information including:
-    related Service Account (#5815)
-    liveness/readiness probe (#6145)
- Major refactoring and improvements of the log viewer (#5868)
- Change resource status icons to colored dots (#5867)
- Add hover effects for clickable elements (#5930)
- Add deployment rollout restart option (#5917)
- Improve env variable display for containers and fix ingress view (#5975)
- Add labels to workload status charts (#5994)
- Restore serialized reference component (#6090)
- Reorganize resource list columns and add more columns, i.e. images (#6014)
- Replace all overview redirects with workloads (#6092)
- Improve chart metrics calculation to support wider time windows (#6126)
- Use stable networking.k8s.io/v1 API for Ingress resource
```
This is automated bump triggered from the source repo containing the updated Chart/Addon.
        