### PR TITLE
[auto-bump][chart] prometheus-elasticsearch-exporter-4.5.0

### DIFF
--- a/addons/elasticsearchexporter/elasticsearchexporter.yaml
+++ b/addons/elasticsearchexporter/elasticsearchexporter.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: elasticsearchexporter
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-6"
-    appversion.kubeaddons.mesosphere.io/elasticsearchexporter: "1.1.0"
-    values.chart.helm.kubeaddons.mesosphere.io/elasticsearchexporter: "https://raw.githubusercontent.com/mesosphere/charts/bf61152/stable/elasticsearch-exporter/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.1-1"
+    appversion.kubeaddons.mesosphere.io/elasticsearchexporter: "1.2.1"
+    values.chart.helm.kubeaddons.mesosphere.io/elasticsearchexporter: "https://raw.githubusercontent.com/mesosphere/charts/8b85fea/stable/elasticsearch-exporter/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -31,7 +31,7 @@ spec:
   chartReference:
     chart: prometheus-elasticsearch-exporter
     repo: https://prometheus-community.github.io/helm-charts
-    version: 4.1.0
+    version: 4.5.0
     values: |
       ---
       # As defined in the readme file when migrating from old chart to new chart


### PR DESCRIPTION
##### Add Release Notes or "None":

```release-note
[FEATURE] Added elasticsearch_clustersettings_stats_max_shards_per_node metric. #277
[FEATURE] Added elasticsearch_indices_shards_store_size_in_bytes metric. #292
[FEATURE] Added --es.indices_mappings flag to scrape elasticsearch index mapping stats and elasticsearch_indices_mappings_stats collector. #411
[FEATURE] Added elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds metric. #318
[ENHANCEMENT] Added support for reloading the tls client certificate in case it changes on disk. #414
[BUGFIX] Fixed the elasticsearch_indices_shards_docs metric name. #291
[BUGFIX] Fixed elasticsearch 7.13 node stats metrics #439
[BUGFIX] Fixed snapshot stats metrics for some snapshot repository types #442
```
This is automated bump triggered from the source repo containing the updated Chart/Addon.
        