### PR TITLE
[auto-bump][chart] kube-prometheus-stack-17.2.1

### DIFF
--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -9,7 +9,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.47.0-4"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.49.0-1"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.47.0"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.26.0"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.21.0"
@@ -17,10 +17,10 @@ metadata:
     endpoint.kubeaddons.mesosphere.io/prometheus: "/ops/portal/prometheus"
     endpoint.kubeaddons.mesosphere.io/alertmanager: "/ops/portal/alertmanager"
     endpoint.kubeaddons.mesosphere.io/grafana: "/ops/portal/grafana"
-    docs.kubeaddons.mesosphere.io/prometheus: "https://prometheus.io/docs/introduction/overview/"
-    docs.kubeaddons.mesosphere.io/grafana: "https://grafana.com/docs/"
-    docs.kubeaddons.mesosphere.io/alertmanager: "https://prometheus.io/docs/alerting/alertmanager/"
-    values.chart.helm.kubeaddons.mesosphere.io/prometheus: "https://raw.githubusercontent.com/mesosphere/charts/c0ec6852189730af8fb34ed2a62b1b79a959bfc5/staging/kube-prometheus-stack/values.yaml"
+    docs.kubeaddons.mesosphere.io/prometheus: "0.49h0.49t0.49t0.49p0.49s0.49:0.49/0.49/0.49p0.49r0.49o0.49m0.49e0.49t0.49h0.49e0.49u0.49s0.49.0.49i0.49o0.49/0.49d0.49o0.49c0.49s0.49/0.49i0.49n0.49t0.49r0.49o0.49d0.49u0.49c0.49t0.49i0.49o0.49n0.49/0.49o0.49v0.49e0.49r0.49v0.49i0.49e0.49w0.49/0.49"
+    docs.kubeaddons.mesosphere.io/grafana: "0.49h0.49t0.49t0.49p0.49s0.49:0.49/0.49/0.49g0.49r0.49a0.49f0.49a0.49n0.49a0.49.0.49c0.49o0.49m0.49/0.49d0.49o0.49c0.49s0.49/0.49"
+    docs.kubeaddons.mesosphere.io/alertmanager: "0.49h0.49t0.49t0.49p0.49s0.49:0.49/0.49/0.49p0.49r0.49o0.49m0.49e0.49t0.49h0.49e0.49u0.49s0.49.0.49i0.49o0.49/0.49d0.49o0.49c0.49s0.49/0.49a0.49l0.49e0.49r0.49t0.49i0.49n0.49g0.49/0.49a0.49l0.49e0.49r0.49t0.49m0.49a0.49n0.49a0.49g0.49e0.49r0.49/0.49"
+    values.chart.helm.kubeaddons.mesosphere.io/prometheus: "https://raw.githubusercontent.com/mesosphere/charts/826b605/staging/kube-prometheus-stack/values.yaml"
     # The prometheus-operator chart from prior Konvoy releases can't be upgraded to 8.10.0.
     # See https://github.com/helm/charts/issues/21200.
     # 8.8.5 was the latest version available in mesosphere/charts before it was bumped past 8.10.0.
@@ -45,7 +45,7 @@ spec:
   chartReference:
     chart: kube-prometheus-stack
     repo: https://mesosphere.github.io/charts/staging
-    version: 15.4.7
+    version: 17.2.1
     valuesRemap:
       "prometheus.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
       "alertmanager.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"


### PR DESCRIPTION

##### Add Release Notes or "None":

```release-note

```
This is automated bump triggered from the source repo containing the updated Chart/Addon.
        