### PR TITLE
[auto-bump][chart] dex-2.9.10

### DIFF
--- a/addons/dex/dex.yaml
+++ b/addons/dex/dex.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dex
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "2.27.0-5"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "2.27.0-6"
     appversion.kubeaddons.mesosphere.io/dex: "2.27.0"
-    values.chart.helm.kubeaddons.mesosphere.io/dex: "https://raw.githubusercontent.com/mesosphere/charts/9c84710/stable/dex/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/dex: "https://raw.githubusercontent.com/mesosphere/charts/f63d2d1/stable/dex/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -34,7 +34,7 @@ spec:
   chartReference:
     chart: dex
     repo: https://mesosphere.github.io/charts/stable
-    version: 2.9.7
+    version: 2.9.10
     values: |
       ---
       # Temporarily we're going to use our custom built container. Documentation


### PR DESCRIPTION
**What type of PR is this?**
Chore

**What this PR does/ why we need it**:

bump dex-controller dep to v0.6.10 to pull in bug make service labels configurable mesosphere/dex-controller#63

**Which issue(s) this PR fixes**:

D2IQ-77936

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

The new version of the `dex-controller`  introduces configurable service labels for the dex-controller chart.

New values introduce for `dex-controller`

```yaml
service:
  common:
    # -- Extra labels for all services
    labels: {}
  metrics:
    # -- Extra labels for metrics service
    labels: {}
  webhook:
    # -- Extra labels for webhook service
    labels: {}
```

With the new version, extra service labels removed from the chart. To continue to support these labels with the new version, the configuration should be updated like:

```yaml
service:
  metric:
    labels:
       servicemonitor.kubeaddons.mesosphere.io/path: metrics
       kubeaddons.mesosphere.io/name: dex-controller
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
