### PR TITLE
[auto-bump][chart] traefik-forward-auth-0.3.3

### DIFF
--- a/addons/traefik-forward-auth/traefik-forward-auth.yaml
+++ b/addons/traefik-forward-auth/traefik-forward-auth.yaml
@@ -37,7 +37,7 @@ spec:
       replicaCount: 1
       image:
         repository: mesosphere/traefik-forward-auth
-        tag: 3.0.1
+        tag: 3.0.2
         pullPolicy: IfNotPresent
       resources:
         requests:

--- a/addons/traefik-forward-auth/traefik-forward-auth.yaml
+++ b/addons/traefik-forward-auth/traefik-forward-auth.yaml
@@ -4,7 +4,7 @@ metadata:
   name: traefik-forward-auth
   namespace: kubeaddons
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "3.1.0-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "3.0.2-1"
     helm.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=1.0.5", "strategy": "delete"}]'
     helm2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=1.0.5", "strategy": "delete"}]'
 spec:
@@ -31,7 +31,7 @@ spec:
   chartReference:
     chart: traefik-forward-auth
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.3.1
+    version: 0.3.3
     values: |
       ---
       replicaCount: 1

--- a/addons/traefik-forward-auth/traefik-forward-auth.yaml
+++ b/addons/traefik-forward-auth/traefik-forward-auth.yaml
@@ -4,7 +4,7 @@ metadata:
   name: traefik-forward-auth
   namespace: kubeaddons
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "3.0.2-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "3.3.0-1"
     helm.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=1.0.5", "strategy": "delete"}]'
     helm2.kubeaddons.mesosphere.io/upgrade-strategy: '[{"upgradeFrom": "<=1.0.5", "strategy": "delete"}]'
 spec:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Bug

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Bumping to TFA >3.0.0 caused below error in YAKCL https://github.com/mesosphere/yakcl/pull/438
```
auth/templates/hooks.yaml failed: Job.batch \"traefik-forward-auth-kommander-kubeaddons-session-key-pre-install\" is invalid: spec.template.labels: Invalid value: \"traefik-forward-auth-kommander-kubeaddons-session-key-pre-install\": must be no more than 63 characters"}
```

I did not find any examples of using `generateName` in our charts and an upstream issue https://github.com/helm/helm/issues/3348 so decided to go with the safer route and just shorten the name to something that will be <=63 characters

```
traefik-forward-auth-kommander-kubeaddons-sess-key-pre-install
traefik-forward-auth-kommander-kubeaddons-sess-key-post-delete
```

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->

**Special notes for your reviewer**:
Testing this fix in https://github.com/mesosphere/yakcl/pull/438


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
traefik-forward-auth: shorten hook names to be within 63 character length.
```


**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
