### PR TITLE
[auto-bump][chart] kubernetes-dashboard-5.0.4

### DIFF
--- a/addons/dashboard/dashboard.yaml
+++ b/addons/dashboard/dashboard.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dashboard
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "3.1.0-1"
-    appversion.kubeaddons.mesosphere.io/dashboard: "2.3.1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "2.4.0-1"
+    appversion.kubeaddons.mesosphere.io/dashboard: "2.4.0"
     endpoint.kubeaddons.mesosphere.io/dashboard: "/ops/portal/kubernetes/"
     docs.kubeaddons.mesosphere.io/dashboard: "https://github.com/kubernetes/dashboard/blob/master/README.md"
     values.chart.helm.kubeaddons.mesosphere.io/dashboard: "https://raw.githubusercontent.com/helm/charts/f4f301a/stable/kubernetes-dashboard/values.yaml"
@@ -33,7 +33,7 @@ spec:
   chartReference:
     chart: kubernetes-dashboard
     repo: https://kubernetes.github.io/dashboard/
-    version: 4.5.0
+    version: 5.0.4
     valuesRemap:
       "ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
     values: |


### PR DESCRIPTION

##### Add Release Notes or "None":

```release-note

```
This is automated bump triggered from the source repo containing the updated Chart/Addon.
        