### PR TITLE
[auto-bump][chart] opsportal-0.9.3

### DIFF
--- a/addons/opsportal/opsportal.yaml
+++ b/addons/opsportal/opsportal.yaml
@@ -6,10 +6,10 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: opsportal
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.0-3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.0-4"
     appversion.kubeaddons.mesosphere.io/opsportal: "1.5.0"
     endpoint.kubeaddons.mesosphere.io/opsportal: /ops/portal/
-    values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/c2a377b/stable/opsportal/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/5fda29e/stable/opsportal/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -29,7 +29,7 @@ spec:
   chartReference:
     chart: opsportal
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.9.1
+    version: 0.9.3
     valuesRemap:
       "kommander-ui.ingress.extraAnnotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
     values: |


### PR DESCRIPTION
Closes D2IQ-81807

**What type of PR is this?**
Feature: [Adds socket monitoring](https://github.com/mesosphere/kommander-ui/commit/37f63d5e851943b6994894602ce782be591bbab7)

Fix: [Pins docker version](https://github.com/mesosphere/kommander-ui/commit/fd51337c218ea9c3b7296ed442cd54459bc473f0)

**What this PR does/ why we need it**:
There is an issue where Kommander UI runs out of ports. This monitors ports and forces a restart if it runs out.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
