### PR TITLE
[auto-bump][chart] metallb-0.12.3

### DIFF
--- a/addons/metallb/metallb.yaml
+++ b/addons/metallb/metallb.yaml
@@ -6,9 +6,9 @@ metadata:
     kubeaddons.mesosphere.io/name: metallb
     kubeaddons.mesosphere.io/provides: loadbalancer
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.9.3-5"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.9.3-6"
     appversion.kubeaddons.mesosphere.io/metallb: "0.9.3"
-    values.chart.helm.kubeaddons.mesosphere.io/metallb: "https://raw.githubusercontent.com/mesosphere/charts/1ce2aaa/stable/metallb/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/metallb: "https://raw.githubusercontent.com/mesosphere/charts/e49f093/stable/metallb/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -45,7 +45,7 @@ spec:
   chartReference:
     chart: metallb
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.12.2
+    version: 0.12.3
     values: |
       ---
       controller:


### PR DESCRIPTION

##### Add Release Notes or "None":

```release-note

```
This is automated bump triggered from the source repo containing the updated Chart/Addon.
        