### PR TITLE
[auto-bump][chart] dex-2.9.11

### DIFF
--- a/addons/dex/dex.yaml
+++ b/addons/dex/dex.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dex
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "2.27.0-5"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "2.27.0-6"
     appversion.kubeaddons.mesosphere.io/dex: "2.27.0"
-    values.chart.helm.kubeaddons.mesosphere.io/dex: "https://raw.githubusercontent.com/mesosphere/charts/9c84710/stable/dex/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/dex: "https://raw.githubusercontent.com/mesosphere/charts/772c9a6/stable/dex/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -34,7 +34,7 @@ spec:
   chartReference:
     chart: dex
     repo: https://mesosphere.github.io/charts/stable
-    version: 2.9.7
+    version: 2.9.11
     values: |
       ---
       # Temporarily we're going to use our custom built container. Documentation


### PR DESCRIPTION

##### Add Release Notes or "None":

```release-note

```
This is automated bump triggered from the source repo containing the updated Chart/Addon.
        