### PR TITLE
[auto-bump][chart] kube-prometheus-stack-18.1.1

### DIFF
--- a/addons/prometheus/prometheus.yaml
+++ b/addons/prometheus/prometheus.yaml
@@ -9,7 +9,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.47.0-5"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.50.0-1"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.47.0"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.29.2"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.21.0"
@@ -17,10 +17,10 @@ metadata:
     endpoint.kubeaddons.mesosphere.io/prometheus: "/ops/portal/prometheus"
     endpoint.kubeaddons.mesosphere.io/alertmanager: "/ops/portal/alertmanager"
     endpoint.kubeaddons.mesosphere.io/grafana: "/ops/portal/grafana"
-    docs.kubeaddons.mesosphere.io/prometheus: "https://prometheus.io/docs/introduction/overview/"
-    docs.kubeaddons.mesosphere.io/grafana: "https://grafana.com/docs/"
-    docs.kubeaddons.mesosphere.io/alertmanager: "https://prometheus.io/docs/alerting/alertmanager/"
-    values.chart.helm.kubeaddons.mesosphere.io/prometheus: "https://raw.githubusercontent.com/mesosphere/charts/c0ec6852189730af8fb34ed2a62b1b79a959bfc5/staging/kube-prometheus-stack/values.yaml"
+    docs.kubeaddons.mesosphere.io/prometheus: "0.50h0.50t0.50t0.50p0.50s0.50:0.50/0.50/0.50p0.50r0.50o0.50m0.50e0.50t0.50h0.50e0.50u0.50s0.50.0.50i0.50o0.50/0.50d0.50o0.50c0.50s0.50/0.50i0.50n0.50t0.50r0.50o0.50d0.50u0.50c0.50t0.50i0.50o0.50n0.50/0.50o0.50v0.50e0.50r0.50v0.50i0.50e0.50w0.50/0.50"
+    docs.kubeaddons.mesosphere.io/grafana: "0.50h0.50t0.50t0.50p0.50s0.50:0.50/0.50/0.50g0.50r0.50a0.50f0.50a0.50n0.50a0.50.0.50c0.50o0.50m0.50/0.50d0.50o0.50c0.50s0.50/0.50"
+    docs.kubeaddons.mesosphere.io/alertmanager: "0.50h0.50t0.50t0.50p0.50s0.50:0.50/0.50/0.50p0.50r0.50o0.50m0.50e0.50t0.50h0.50e0.50u0.50s0.50.0.50i0.50o0.50/0.50d0.50o0.50c0.50s0.50/0.50a0.50l0.50e0.50r0.50t0.50i0.50n0.50g0.50/0.50a0.50l0.50e0.50r0.50t0.50m0.50a0.50n0.50a0.50g0.50e0.50r0.50/0.50"
+    values.chart.helm.kubeaddons.mesosphere.io/prometheus: "https://raw.githubusercontent.com/mesosphere/charts/772c9a6/staging/kube-prometheus-stack/values.yaml"
     # The prometheus-operator chart from prior Konvoy releases can't be upgraded to 8.10.0.
     # See https://github.com/helm/charts/issues/21200.
     # 8.8.5 was the latest version available in mesosphere/charts before it was bumped past 8.10.0.
@@ -45,7 +45,7 @@ spec:
   chartReference:
     chart: kube-prometheus-stack
     repo: https://mesosphere.github.io/charts/staging
-    version: 15.4.7
+    version: 18.1.1
     valuesRemap:
       "prometheus.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"
       "alertmanager.ingress.annotations.traefik\\.ingress\\.kubernetes\\.io/auth-url": "ingress.auth.auth-url"


### PR DESCRIPTION

##### Add Release Notes or "None":

```release-note

```
This is automated bump triggered from the source repo containing the updated Chart/Addon.
        