### PR TITLE
[auto-bump][chart] kube-oidc-proxy-0.3.0

### DIFF
--- a/addons/kube-oidc-proxy/kube-oidc-proxy.yaml
+++ b/addons/kube-oidc-proxy/kube-oidc-proxy.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kube-oidc-proxy
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.2.0-4"
-    appversion.kubeaddons.mesosphere.io/kube-oidc-proxy: "v0.2.0"
-    values.chart.helm.kubeaddons.mesosphere.io/kube-oidc-proxy: "https://raw.githubusercontent.com/mesosphere/charts/9c84710/staging/kube-oidc-proxy/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "v0.3.0-1"
+    appversion.kubeaddons.mesosphere.io/kube-oidc-proxy: "v0.3.0"
+    values.chart.helm.kubeaddons.mesosphere.io/kube-oidc-proxy: "https://raw.githubusercontent.com/mesosphere/charts/8cd072f/staging/kube-oidc-proxy/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -36,7 +36,7 @@ spec:
   chartReference:
     chart: kube-oidc-proxy
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.2.7
+    version: 0.3.0
     values: |
       ---
       image:


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What this PR does/ why we need it**:
Bump kube-oidc-proxy to 0.3.0

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-82948

**Special notes for your reviewer**:
I tried to add to the chart things/changes that were introduced upstream since our last bump (to 0.2.0 in 1b9a4b392d13fa66f395eb854b57c962ca015969). I assume that the 0.2.0 bump did the same.

Tested with: mesosphere/kommander#1389 and manually with k20 - 1655a43c773009fb9d97cb940d7758d9370156b3, and latest konvoy (also manually).

The manual test consisted of launching the cluster, confirming that 0.3.0 was deployed, obtaining the token, and logging into the cluster and listing pods using it.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
* bump kube-oidc-proxy to 0.3.0
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
