### PR TITLE
updating default-storage-class addon to latest chart version

### DIFF
--- a/addons/defaultstorageclass-protection/defaultstorageclass-protection.yaml
+++ b/addons/defaultstorageclass-protection/defaultstorageclass-protection.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: defaultstorageclass-protection
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-0"
-    appversion.kubeaddons.mesosphere.io/defaultstorageclass-protection: "0.0.6"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-1"
+    appversion.kubeaddons.mesosphere.io/defaultstorageclass-protection: "0.1.0"
     # version 0.0.5 changed the selectors
     helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<0.0.5\", \"strategy\": \"delete\"}]"
 spec:
@@ -32,7 +32,7 @@ spec:
   chartReference:
     chart: defaultstorageclass
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.0.6
+    version: 0.1.0
     values: |
       ---
       issuer:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/mesosphere/kubernetes-base-addons/blob/master/CONTRIBUTING.md

-->

**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore update addon to use latest chart

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue."
* jql=key in (D2IQ-<NUMBER>)
* https://jira.d2iq.com/browse/D2iQ-<NUMBER>
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
If the change fixes a COPS issue, you must include a relevant release note below.
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Use a chart version that has no reference to "latest" tag of default-storage-class
```

**Checklist**

* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
