### PR TITLE
[auto-bump][chart] dex-k8s-authenticator-1.2.9

### DIFF
--- a/addons/dex-k8s-authenticator/dex-k8s-authenticator.yaml
+++ b/addons/dex-k8s-authenticator/dex-k8s-authenticator.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dex-k8s-authenticator
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.2-7"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.2-8"
     appversion.kubeaddons.mesosphere.io/dex-k8s-authenticator: "v1.2.2"
-    values.chart.helm.kubeaddons.mesosphere.io/dex-k8s-authenticator: "https://raw.githubusercontent.com/mesosphere/charts/679ae2a/staging/dex-k8s-authenticator/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/dex-k8s-authenticator: "https://raw.githubusercontent.com/mesosphere/charts/b351c82/staging/dex-k8s-authenticator/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -33,7 +33,7 @@ spec:
   chartReference:
     chart: dex-k8s-authenticator
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.2.8
+    version: 1.2.9
     values: |
       ---
       image:


### PR DESCRIPTION
**What type of PR is this?**
<!-- Bug, Chore, Documentation, Feature -->
Chore

**What this PR does/ why we need it**:
<!-- Explain, without going into the details, what this PR does, and what problem it solves. -->
Updates charts definitions where `Ingress` objects were using deprecated `extensions/v1beta1` or `networking.k8s.io/v1` API versions that were removed from k8s 1.22. Updated charts:

```
dex-k8s-authenticator
kube-oidc-proxy
karma
mtls-proxy
traefik-forward-auth
```

**Which issue(s) this PR fixes**:
<!-- Add a link to the JIRA issue. Otherwise, put "no issue." -->
https://jira.d2iq.com/browse/D2IQ-81723

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
