### PR TITLE
[auto-bump][chart] kube-oidc-proxy-0.3.1

### DIFF
--- a/addons/kube-oidc-proxy/kube-oidc-proxy.yaml
+++ b/addons/kube-oidc-proxy/kube-oidc-proxy.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kube-oidc-proxy
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "v0.3.0-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "v0.3.0-2"
     appversion.kubeaddons.mesosphere.io/kube-oidc-proxy: "v0.3.0"
-    values.chart.helm.kubeaddons.mesosphere.io/kube-oidc-proxy: "https://raw.githubusercontent.com/mesosphere/charts/8cd072f/staging/kube-oidc-proxy/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/kube-oidc-proxy: "https://raw.githubusercontent.com/mesosphere/charts/1e39d8e/staging/kube-oidc-proxy/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.6
@@ -36,7 +36,7 @@ spec:
   chartReference:
     chart: kube-oidc-proxy
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.3.0
+    version: 0.3.1
     values: |
       ---
       image:


### PR DESCRIPTION

##### Add Release Notes or "None":

```release-note

```
This is automated bump triggered from the source repo containing the updated Chart/Addon.
        