### PR TITLE
[auto-bump][chart] velero-3.2.0

### DIFF
--- a/addons/velero/velero.yaml
+++ b/addons/velero/velero.yaml
@@ -30,8 +30,8 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.0-1"
-    values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/mesosphere/charts/8b85fea/staging/velero/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.2-1"
+    values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/mesosphere/charts/1e39d8e/staging/velero/values.yaml"
     # minio StatefulSet changes too much to be updated
     helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=3.0.6\", \"strategy\": \"delete\"}]"
     helm2.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=3.0.6\", \"strategy\": \"delete\"}]"
@@ -56,7 +56,7 @@ spec:
   chartReference:
     chart: velero
     repo: https://mesosphere.github.io/charts/staging
-    version: 3.1.3
+    version: 3.2.0
     values: |
       ---
       enableHelmHooks: false # handle helm install --atomic through kubeaddons


### PR DESCRIPTION

##### Add Release Notes or "None":

```release-note

```
This is automated bump triggered from the source repo containing the updated Chart/Addon.
        