### PR TITLE
[auto-bump][chart] velero-3.2.2

### DIFF
--- a/addons/velero/velero.yaml
+++ b/addons/velero/velero.yaml
@@ -30,8 +30,8 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.6.0-1"
-    values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/mesosphere/charts/8b85fea/staging/velero/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.5.2-1"
+    values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/mesosphere/charts/3560da3/staging/velero/values.yaml"
     # minio StatefulSet changes too much to be updated
     helm.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=3.0.6\", \"strategy\": \"delete\"}]"
     helm2.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=3.0.6\", \"strategy\": \"delete\"}]"
@@ -56,7 +56,7 @@ spec:
   chartReference:
     chart: velero
     repo: https://mesosphere.github.io/charts/staging
-    version: 3.1.3
+    version: 3.2.2
     values: |
       ---
       enableHelmHooks: false # handle helm install --atomic through kubeaddons


### PR DESCRIPTION
**What type of PR is this?**
chore

**What this PR does/ why we need it**:
Minor bumps of kubectl 1.2x (most are 1.23, but at least one is 1.21). This is to catch CVE fixes in the build artifacts.

**Which issue(s) this PR fixes**:
Partially fixes...
[D2IQ-90196](https://jira.d2iq.com/browse/D2IQ-90196)
[D2IQ-89723](https://jira.d2iq.com/browse/D2IQ-89723)
[D2IQ-90200](https://jira.d2iq.com/browse/D2IQ-90200)
[D2IQ-89801](https://jira.d2iq.com/browse/D2IQ-89801)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

* [x] *If a chart is changed, the chart version is correctly incremented.*
* [x] The commit message explains the changes and why are needed.
* [x] The code builds and passes lint/style checks locally.
* [x] The relevant subset of integration tests pass locally.
* [x] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
