### PR TITLE
[auto-bump][chart] istio-1.13.5

### DIFF
--- a/addons/istio/istio.yaml
+++ b/addons/istio/istio.yaml
@@ -8,10 +8,10 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: istio
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.9.1-1"
-    appversion.kubeaddons.mesosphere.io/istio: "1.9.1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.13.4-1"
+    appversion.kubeaddons.mesosphere.io/istio: "1.13.4"
     docs.kubeaddons.mesosphere.io/istio: "https://istio.io/docs/"
-    values.chart.helm.kubeaddons.mesosphere.io/istio: "https://raw.githubusercontent.com/mesosphere/charts/1749586/staging/istio/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/istio: "https://raw.githubusercontent.com/mesosphere/charts/e8caefe/staging/istio/values.yaml"
 spec:
   namespace: istio-system
   requires:
@@ -36,7 +36,7 @@ spec:
   chartReference:
     chart: istio
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.9.1
+    version: 1.13.5
     values: |
       istioOperator:
         components:


### PR DESCRIPTION
**What type of PR is this?**
chore

**What this PR does/ why we need it**:
Bumps kubectl to 1.24.1 across all charts used by kommander-applications.

**Which issue(s) this PR fixes**:
https://jira.d2iq.com/browse/D2IQ-90193
https://jira.d2iq.com/browse/D2IQ-90194

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

* [ ] *If a chart is changed, the chart version is correctly incremented.*
* [ ] The commit message explains the changes and why are needed.
* [ ] The code builds and passes lint/style checks locally.
* [ ] The relevant subset of integration tests pass locally.
* [ ] The core changes are covered by tests.
* [ ] The documentation is updated where needed.
